### PR TITLE
Fix TenVADWorkerClient unhandled error log

### DIFF
--- a/src/lib/vad/TenVADWorkerClient.ts
+++ b/src/lib/vad/TenVADWorkerClient.ts
@@ -113,7 +113,9 @@ export class TenVADWorkerClient {
                 this.pendingPromises.delete(msg.id);
                 p.reject(new Error(msg.payload));
             } else {
-                console.error('[TenVADWorkerClient] Unhandled error:', msg.payload);
+                // If the promise is missing, it was likely already rejected by worker.onerror
+                // or the client was disposed. Log as warn/debug instead of error to reduce noise.
+                console.warn('[TenVADWorkerClient] Received error for unknown/handled request:', msg.payload);
             }
             return;
         }

--- a/src/lib/vad/tenvad.worker.ts
+++ b/src/lib/vad/tenvad.worker.ts
@@ -144,7 +144,9 @@ async function handleInit(id: number, cfg: { hopSize: number; threshold: number;
 
         respond({ type: 'INIT', id, payload: { success: true, version } });
     } catch (err) {
-        console.error('[TenVAD Worker] Init failed:', err);
+        // Initialization failures are handled by the main thread (client rejects promise).
+        // Log as warn instead of error to reduce noise during tests where failure is expected.
+        console.warn('[TenVAD Worker] Init failed:', err);
         respond({ type: 'ERROR', id, payload: `TEN-VAD init failed: ${err}` });
     }
 }


### PR DESCRIPTION
Modified `src/lib/vad/TenVADWorkerClient.ts` to log a warning instead of an error when an error message is received for an unknown request ID. This handles race conditions where `worker.onerror` or `dispose` has already cleared the pending promise.

---
*PR created automatically by Jules for task [6466884898578238860](https://jules.google.com/task/6466884898578238860) started by @ysdede*