### PR TITLE
🧹 Remove unused dependency: lz4js

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@solid-primitives/transition-group": "^1.1.2",
     "@thisbeyond/solid-dnd": "^0.7.5",
     "lodash.debounce": "^4.0.8",
-    "lz4js": "^0.2.0",
     "material-icons": "^1.13.14",
     "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4",
     "parakeet.js": "^1.0.1",


### PR DESCRIPTION
This PR removes the unused `lz4js` dependency from `package.json` to reduce bundle size and installation time.

**What:** Removed `lz4js` from `package.json`.
**Why:** It is an unused dependency.
**Verification:** Verified by running `npm test` and `npm run build`, both passed.
**Result:** Cleaner `package.json`.

---
*PR created automatically by Jules for task [11009132384533505572](https://jules.google.com/task/11009132384533505572) started by @ysdede*