### PR TITLE
🧹 Remove dead code `energyTrends` from AudioSegmentProcessor

### DIFF
--- a/src/lib/audio/AudioSegmentProcessor.test.ts
+++ b/src/lib/audio/AudioSegmentProcessor.test.ts
@@ -1,0 +1,69 @@
+
+import { describe, it, expect } from 'vitest';
+import { AudioSegmentProcessor } from './AudioSegmentProcessor';
+
+describe('AudioSegmentProcessor', () => {
+    it('should initialize without errors', () => {
+        const processor = new AudioSegmentProcessor();
+        expect(processor).toBeDefined();
+        const stats = processor.getStats();
+        expect(stats).toBeDefined();
+        expect(stats.noiseFloor).toBeGreaterThan(0);
+    });
+
+    it('should process silence without detecting segments', () => {
+        const processor = new AudioSegmentProcessor({
+            sampleRate: 16000,
+            energyThreshold: 0.1
+        });
+
+        // 16000 samples = 1 second
+        const silence = new Float32Array(16000).fill(0);
+        const energy = 0.0001;
+        const currentTime = 1.0;
+
+        const segments = processor.processAudioData(silence, currentTime, energy);
+
+        expect(segments).toEqual([]);
+        const state = processor.getStateInfo();
+        expect(state.inSpeech).toBe(false);
+    });
+
+    it('should process speech and detect segments', () => {
+        // This is a simplified test.
+        // Real VAD is complex, so we just check state transitions if we force high energy
+        const processor = new AudioSegmentProcessor({
+            sampleRate: 16000,
+            energyThreshold: 0.01
+        });
+
+        const speech = new Float32Array(1600).fill(0.5); // 100ms
+        const energy = 0.5; // High energy
+
+        // Process a few chunks to trigger speech detection
+        let segments = processor.processAudioData(speech, 1.0, energy);
+
+        // It might not trigger immediately due to lookback/SNR checks,
+        // but let's check internal state or just that it doesn't crash
+
+        // Force state check
+        // processor.processAudioData is complex, so let's just ensure it runs
+        expect(Array.isArray(segments)).toBe(true);
+    });
+
+    it('should reset state correctly', () => {
+        const processor = new AudioSegmentProcessor();
+
+        // Simulate some state change
+        const chunk = new Float32Array(100).fill(0.1);
+        processor.processAudioData(chunk, 1.0, 0.5);
+
+        processor.reset();
+
+        const stats = processor.getStats();
+        expect(stats.noiseFloor).toBe(0.005); // Default reset value
+        const state = processor.getStateInfo();
+        expect(state.inSpeech).toBe(false);
+        expect(state.speechStartTime).toBeNull();
+    });
+});

--- a/src/lib/audio/AudioSegmentProcessor.ts
+++ b/src/lib/audio/AudioSegmentProcessor.ts
@@ -63,7 +63,6 @@ interface ProcessorState {
     noiseFloor: number;
     recentEnergies: number[];
     silenceDuration: number;
-    energyTrends: number[];
 }
 
 /** Segment output */
@@ -530,8 +529,7 @@ export class AudioSegmentProcessor {
             segmentCounter: 0,
             noiseFloor: 0.005,
             recentEnergies: [],
-            silenceDuration: 0,
-            energyTrends: []
+            silenceDuration: 0
         };
     }
 


### PR DESCRIPTION
This PR removes the `energyTrends` field from the `AudioSegmentProcessor` class. This field was defined in the `ProcessorState` interface and initialized in the `reset` method but was never used in the implementation logic.

**Changes:**
- Removed `energyTrends` from `ProcessorState` interface in `src/lib/audio/AudioSegmentProcessor.ts`.
- Removed `energyTrends: []` initialization in `reset()` method in `src/lib/audio/AudioSegmentProcessor.ts`.
- Created `src/lib/audio/AudioSegmentProcessor.test.ts` to verify that the removal does not affect the functionality of the class.

**Verification:**
- Ran `npm test src/lib/audio/AudioSegmentProcessor.test.ts` and confirmed that the tests pass.
- Ran `npm test` to ensure no regressions in other parts of the codebase.

---
*PR created automatically by Jules for task [2080989709620844691](https://jules.google.com/task/2080989709620844691) started by @ysdede*