### PR TITLE
chore: remove unused lodash.debounce dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@huggingface/transformers": "^3.6.1",
     "@solid-primitives/transition-group": "^1.1.2",
     "@thisbeyond/solid-dnd": "^0.7.5",
-    "lodash.debounce": "^4.0.8",
     "lz4js": "^0.2.0",
     "material-icons": "^1.13.14",
     "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4",


### PR DESCRIPTION
Removed `lodash.debounce` from `package.json` after confirming it is not used in the codebase.
Ran `npm install` and verified tests passed.
`package-lock.json` was not committed as it is ignored in `.gitignore`.

---
*PR created automatically by Jules for task [6184624572109551568](https://jules.google.com/task/6184624572109551568) started by @ysdede*