### PR TITLE
🧹 [Code Health] Remove dead code `lastProcessorStats` from AudioEngine

### DIFF
--- a/src/lib/audio/AudioEngine.ts
+++ b/src/lib/audio/AudioEngine.ts
@@ -39,9 +39,6 @@ export class AudioEngine implements IAudioEngine {
     private audioProcessor: AudioSegmentProcessor; // Replaces EnergyVAD
     private deviceId: string | null = null;
 
-    // Cache last stats for UI
-    private lastProcessorStats: any = null;
-
     private audioContext: AudioContext | null = null;
     private mediaStream: MediaStream | null = null;
     private workletNode: AudioWorkletNode | null = null;


### PR DESCRIPTION
🎯 **What:** Removed the unused private property `lastProcessorStats` from `src/lib/audio/AudioEngine.ts`.
💡 **Why:** The property was dead code (initialized but never used), and removing it improves code cleanliness and maintainability.
✅ **Verification:** Verified by grepping the codebase to confirm no usages existed and running the full test suite (`npm test`) to ensure no regressions.
✨ **Result:** Cleaner `AudioEngine` class implementation.


---
*PR created automatically by Jules for task [10793417850540353765](https://jules.google.com/task/10793417850540353765) started by @ysdede*