### PR TITLE
Remove unused segmentCounter from AudioSegmentProcessor

### DIFF
--- a/src/lib/audio/AudioSegmentProcessor.ts
+++ b/src/lib/audio/AudioSegmentProcessor.ts
@@ -59,7 +59,6 @@ interface ProcessorState {
     speechStats: SegmentStats[];
     silenceStats: SegmentStats[];
     currentStats: CurrentStats;
-    segmentCounter: number;
     noiseFloor: number;
     recentEnergies: number[];
     silenceDuration: number;
@@ -526,7 +525,6 @@ export class AudioSegmentProcessor {
                 minSnrThreshold: this.options.minSnrThreshold,
                 energyRiseThreshold: this.options.energyRiseThreshold
             },
-            segmentCounter: 0,
             noiseFloor: 0.005,
             recentEnergies: [],
             silenceDuration: 0


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
  Removed the unused `segmentCounter` field from `AudioSegmentProcessor.ts`.

💡 **Why:** How this improves maintainability
  Dead code can be confusing and misleading. Removing it makes the code cleaner and easier to understand.

✅ **Verification:** How you confirmed the change is safe
  - Verified that `segmentCounter` is not used anywhere else in the file using `grep`.
  - Ran `bun test src/lib/audio/AudioSegmentProcessor.test.ts` and all tests passed.

✨ **Result:** The improvement achieved
  Cleaner `AudioSegmentProcessor.ts` without unused fields.

---
*PR created automatically by Jules for task [5248757146693136409](https://jules.google.com/task/5248757146693136409) started by @ysdede*