### PR TITLE
Remove unused wavefile dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "parakeet.js": "^1.0.1",
     "solid-js": "^1.9.5",
     "uuid": "^11.1.0",
-    "wavefile": "^11.0.0",
     "wink-eng-lite-web-model": "^1.8.1",
     "wink-nlp": "^2.4.0"
   }


### PR DESCRIPTION
* 🎯 **What:** Removed `wavefile` from `package.json`.
* 💡 **Why:** It was identified as an unused dependency, bloating the dependency tree. The codebase (specifically `src/lib/audio/mel-e2e.test.ts`) uses a custom WAV parser instead of this library.
* ✅ **Verification:** Verified by `grep` searching the codebase for usages (none found) and running `npm test` (specifically `mel-e2e.test.ts` passed successfully).
* ✨ **Result:** Cleaner `package.json` and reduced potential install size/time.

---
*PR created automatically by Jules for task [3207908049497616416](https://jules.google.com/task/3207908049497616416) started by @ysdede*