### PR TITLE
Refactor: Extract resampleLinear to shared utils

### DIFF
--- a/src/lib/audio/AudioEngine.ts
+++ b/src/lib/audio/AudioEngine.ts
@@ -1,30 +1,7 @@
 import { AudioEngine as IAudioEngine, AudioEngineConfig, AudioSegment, IRingBuffer, AudioMetrics } from './types';
 import { RingBuffer } from './RingBuffer';
 import { AudioSegmentProcessor, ProcessedSegment } from './AudioSegmentProcessor';
-
-/**
- * Simple linear interpolation resampler for downsampling audio.
- * Good enough for speech recognition where we're going 48kHz -> 16kHz.
- */
-function resampleLinear(input: Float32Array, fromRate: number, toRate: number): Float32Array {
-    if (fromRate === toRate) return input;
-
-    const ratio = fromRate / toRate;
-    const outputLength = Math.floor(input.length / ratio);
-    const output = new Float32Array(outputLength);
-
-    for (let i = 0; i < outputLength; i++) {
-        const srcIndex = i * ratio;
-        const srcIndexFloor = Math.floor(srcIndex);
-        const srcIndexCeil = Math.min(srcIndexFloor + 1, input.length - 1);
-        const t = srcIndex - srcIndexFloor;
-
-        // Linear interpolation
-        output[i] = input[srcIndexFloor] * (1 - t) + input[srcIndexCeil] * t;
-    }
-
-    return output;
-}
+import { resampleLinear } from './utils';
 
 /** Duration of the visualization buffer in seconds */
 const VISUALIZATION_BUFFER_DURATION = 30;

--- a/src/lib/audio/mel-e2e.test.ts
+++ b/src/lib/audio/mel-e2e.test.ts
@@ -32,6 +32,7 @@ import {
     normalizeMelFeatures,
     sampleToFrame,
 } from './mel-math';
+import { resampleLinear } from './utils';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
@@ -116,25 +117,6 @@ function parseWav(buffer: ArrayBuffer): { audio: Float32Array; sampleRate: numbe
     }
 
     return { audio, sampleRate, channels };
-}
-
-/**
- * Resample audio from sourceSR to targetSR using simple linear interpolation.
- * Good enough for tests; real apps use AudioContext.
- */
-function resampleLinear(audio: Float32Array, sourceSR: number, targetSR: number): Float32Array {
-    if (sourceSR === targetSR) return audio;
-    const ratio = sourceSR / targetSR;
-    const outLen = Math.floor(audio.length / ratio);
-    const out = new Float32Array(outLen);
-    for (let i = 0; i < outLen; i++) {
-        const srcIdx = i * ratio;
-        const lo = Math.floor(srcIdx);
-        const hi = Math.min(lo + 1, audio.length - 1);
-        const frac = srcIdx - lo;
-        out[i] = audio[lo] * (1 - frac) + audio[hi] * frac;
-    }
-    return out;
 }
 
 /**

--- a/src/lib/audio/utils.ts
+++ b/src/lib/audio/utils.ts
@@ -1,0 +1,23 @@
+/**
+ * Simple linear interpolation resampler for downsampling audio.
+ * Good enough for speech recognition where we're going 48kHz -> 16kHz.
+ */
+export function resampleLinear(input: Float32Array, fromRate: number, toRate: number): Float32Array {
+    if (fromRate === toRate) return input;
+
+    const ratio = fromRate / toRate;
+    const outputLength = Math.floor(input.length / ratio);
+    const output = new Float32Array(outputLength);
+
+    for (let i = 0; i < outputLength; i++) {
+        const srcIndex = i * ratio;
+        const srcIndexFloor = Math.floor(srcIndex);
+        const srcIndexCeil = Math.min(srcIndexFloor + 1, input.length - 1);
+        const t = srcIndex - srcIndexFloor;
+
+        // Linear interpolation
+        output[i] = input[srcIndexFloor] * (1 - t) + input[srcIndexCeil] * t;
+    }
+
+    return output;
+}


### PR DESCRIPTION
Extracted `resampleLinear` to a shared utility file `src/lib/audio/utils.ts` to improve reusability and remove code duplication between `AudioEngine.ts` and `mel-e2e.test.ts`. This improves the maintainability of the audio processing codebase.

---
*PR created automatically by Jules for task [11489041640611973291](https://jules.google.com/task/11489041640611973291) started by @ysdede*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated audio resampling utility to a centralized module for improved code maintainability and reusability across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->