### PR TITLE
Add Content Security Policy (CSP)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://huggingface.co https://*.huggingface.co https://*.hf.co https://fonts.googleapis.com https://fonts.gstatic.com; font-src 'self' https://fonts.gstatic.com; frame-src 'self'; img-src 'self' data:; object-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; worker-src 'self' blob:;" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="BoncukJS - Privacy-first real-time transcription. Your audio stays on your device." />
   <meta name="theme-color" content="#135bec" />

--- a/src/csp.test.ts
+++ b/src/csp.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { Window } from 'happy-dom';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe('Content Security Policy', () => {
+  it('should be present in index.html', () => {
+    const htmlPath = path.resolve(__dirname, '../index.html');
+    const html = fs.readFileSync(htmlPath, 'utf-8');
+    const window = new Window();
+    const document = window.document;
+    document.write(html);
+
+    const meta = document.querySelector('meta[http-equiv="Content-Security-Policy"]');
+    expect(meta).not.toBeNull();
+
+    const content = meta?.getAttribute('content') || '';
+
+    // Check for critical directives
+    expect(content).toContain("default-src 'self'");
+    expect(content).toContain("script-src 'self'");
+    expect(content).toContain("object-src 'none'");
+
+    // Check specific allowances
+    expect(content).toContain('https://huggingface.co');
+    expect(content).toContain('https://*.hf.co');
+    expect(content).toContain('blob:'); // For workers
+    expect(content).toContain("worker-src 'self' blob:");
+  });
+});


### PR DESCRIPTION
## 🎯 What
Added a Content Security Policy (CSP) `<meta>` tag to `index.html`.

## ⚠️ Risk
Without CSP, the application is vulnerable to Cross-Site Scripting (XSS) and data injection attacks.

## 🛡️ Solution
The new CSP restricts content sources to:
-   `default-src 'self'`
-   `connect-src`: Allows connections to Hugging Face (for models), Google Fonts, and self.
-   `script-src`: Allows self, inline scripts (needed for app initialization), `unsafe-eval` (required for ONNX Runtime WASM), and blob (for workers).
-   `worker-src`: Allows self and blob (for dynamic worker loading).
-   `object-src 'none'`: Blocks plugins.

Added `src/csp.test.ts` to verify the CSP is present and correctly configured.

---
*PR created automatically by Jules for task [1224298699811174671](https://jules.google.com/task/1224298699811174671) started by @ysdede*