### PR TITLE
Security Fix: Self-host fonts to eliminate missing SRI vulnerability

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,11 +10,6 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <title>Boncuk AI - Real-time Transcription</title>
   
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" />
-  
   <!-- PWA Manifest -->
   <link rel="manifest" href="/manifest.json" />
   <link rel="icon" type="image/x-icon" href="/src/assets/favicon.ico" />

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
+    "@fontsource-variable/manrope": "^5.2.8",
+    "@fontsource-variable/material-symbols-outlined": "^5.2.33",
     "@google/generative-ai": "^0.24.1",
     "@huggingface/transformers": "^3.6.1",
     "@solid-primitives/transition-group": "^1.1.2",

--- a/src/components/BufferVisualizer.tsx
+++ b/src/components/BufferVisualizer.tsx
@@ -193,7 +193,7 @@ export const BufferVisualizer: Component<BufferVisualizerProps> = (props) => {
 
         // Label (Etched text)
         ctx.fillStyle = isDarkMode ? 'rgba(255, 255, 255, 0.15)' : 'rgba(0, 0, 0, 0.2)';
-        ctx.font = '900 9px "JetBrains Mono", monospace';
+        ctx.font = '900 9px "JetBrains Mono Variable", monospace';
         const labelY = centerY - adaptiveThreshold * centerY - 8;
         ctx.fillText(`THRSH: ${snrThreshold().toFixed(1)}dB`, 10, labelY);
       }
@@ -289,7 +289,7 @@ export const BufferVisualizer: Component<BufferVisualizerProps> = (props) => {
 
         // Digital Readout
         ctx.fillStyle = isDarkMode ? '#f8fafc' : '#1e293b';
-        ctx.font = '900 10px "JetBrains Mono", monospace';
+        ctx.font = '900 10px "JetBrains Mono Variable", monospace';
         ctx.textAlign = 'right';
         ctx.fillText(`${currentMetrics.currentSNR.toFixed(0)}`, meterX - 8, thresholdMarkerY + 4);
         ctx.textAlign = 'left';

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap');
 @import "tailwindcss";
 
 @theme {
@@ -7,8 +6,8 @@
   --color-workspace-bg: #f9fafc;
   --color-sidebar-border: #d1d5db;
 
-  --font-display: "Manrope", sans-serif;
-  --font-sans: "Manrope", sans-serif;
+  --font-display: "Manrope Variable", sans-serif;
+  --font-sans: "Manrope Variable", sans-serif;
 
   --shadow-neu-flat: 6px 6px 12px #c8cdd8, -6px -6px 12px #ffffff;
   --shadow-neu-pressed: inset 4px 4px 8px #c8cdd8, inset -4px -4px 8px #ffffff;
@@ -18,7 +17,7 @@
 
 /* Material Symbols - ensure they load and look sharp. */
 .material-symbols-outlined {
-  font-family: 'Material Symbols Outlined' !important;
+  font-family: 'Material Symbols Outlined Variable' !important;
   font-weight: normal;
   font-style: normal;
   font-size: 24px;
@@ -108,7 +107,7 @@ body {
 code,
 pre,
 .font-mono {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: 'JetBrains Mono Variable', monospace;
 }
 
 /* Waveform animation */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,9 @@
 
 /* @refresh reload */
 import { render } from 'solid-js/web';
+import '@fontsource-variable/manrope';
+import '@fontsource-variable/jetbrains-mono';
+import '@fontsource-variable/material-symbols-outlined/full.css';
 import App from './App';
 import './index.css';
 


### PR DESCRIPTION
🔒 Security Fix: Self-host fonts to eliminate missing SRI vulnerability

* 🎯 **What:** Replaced Google Fonts CDN links with self-hosted `@fontsource-variable` packages for Manrope, JetBrains Mono, and Material Symbols.
* ⚠️ **Risk:** Loading fonts from a third-party CDN without Subresource Integrity (SRI) exposes the application to potential CSS injection attacks if the CDN is compromised or traffic is intercepted. Google Fonts does not support SRI for CSS requests due to dynamic content based on User-Agent.
* 🛡️ **Solution:** Installed npm packages (`@fontsource-variable/manrope`, `@fontsource-variable/jetbrains-mono`, `@fontsource-variable/material-symbols-outlined`) to bundle fonts with the application. Updated `src/index.tsx`, `src/index.css`, and `src/components/BufferVisualizer.tsx` to use the local font files and correct variable font family names. This ensures all assets are served from the same origin and are covered by the application's integrity checks.
* **Verified:** Verified visually that fonts load correctly using a Playwright script. Build passes. Tests pass (except known flake in TenVADWorkerClient).

---
*PR created automatically by Jules for task [8116310505920922195](https://jules.google.com/task/8116310505920922195) started by @ysdede*