### PR TITLE
Refactor TranscriptionWorkerClient to use discriminated union types

### DIFF
--- a/src/lib/transcription/WorkerMessages.ts
+++ b/src/lib/transcription/WorkerMessages.ts
@@ -1,0 +1,58 @@
+import type {
+    ModelProgress,
+    ModelState,
+    TranscriptionResult
+} from './types';
+import type { TokenStreamResult } from './TokenStreamTranscriber';
+import type { MergerResult, MergerStats } from './UtteranceBasedMerger';
+
+/** Incremental cache parameters for v4 transcription */
+export interface V4IncrementalCache {
+    cacheKey: string;
+    prefixSeconds: number;
+}
+
+/** Result from v4 utterance-based processing (processed chunk) */
+export interface V4ProcessResult {
+    matureText: string;
+    immatureText: string;
+    matureCursorTime: number;
+    fullText: string;
+    metrics?: any;
+    totalSentences: number;
+    matureSentenceCount: number;
+    pendingSentence: string | null;
+    stats: MergerStats;
+}
+
+/** Result from v4 timeout finalization (subset of V4ProcessResult) */
+export interface V4TimeoutResult {
+    matureText: string;
+    immatureText: string;
+    matureCursorTime: number;
+    fullText: string;
+}
+
+/** Discriminated union of all messages sent from the worker to the client */
+export type WorkerMessage =
+    // Reactive Notifications
+    | { type: 'MODEL_PROGRESS'; payload: ModelProgress; id?: undefined }
+    | { type: 'MODEL_STATE'; payload: ModelState; id?: undefined }
+    | { type: 'V3_CONFIRMED'; payload: { text: string; words: any[] }; id?: undefined }
+    | { type: 'V3_PENDING'; payload: { text: string; words: any[] }; id?: undefined }
+    | { type: 'ERROR'; payload: string; id?: number } // Error can be notification or response
+
+    // Responses to Requests
+    | { type: 'INIT_MODEL_DONE'; payload?: undefined; id: number }
+    | { type: 'INIT_SERVICE_DONE'; payload?: undefined; id: number }
+    | { type: 'INIT_V3_SERVICE_DONE'; payload?: undefined; id: number }
+    | { type: 'PROCESS_CHUNK_DONE'; payload: TranscriptionResult; id: number }
+    | { type: 'PROCESS_V3_CHUNK_DONE'; payload: TokenStreamResult; id: number }
+    | { type: 'PROCESS_V3_CHUNK_WITH_FEATURES_DONE'; payload: TokenStreamResult; id: number }
+    | { type: 'TRANSCRIBE_SEGMENT_DONE'; payload: TranscriptionResult; id: number }
+    | { type: 'RESET_DONE'; payload?: undefined; id: number }
+    | { type: 'FINALIZE_DONE'; payload: TranscriptionResult | TokenStreamResult | MergerResult | { text: string }; id: number }
+    | { type: 'INIT_V4_SERVICE_DONE'; payload?: undefined; id: number }
+    | { type: 'PROCESS_V4_CHUNK_WITH_FEATURES_DONE'; payload: V4ProcessResult; id: number }
+    | { type: 'V4_FINALIZE_TIMEOUT_DONE'; payload: V4TimeoutResult | null; id: number }
+    | { type: 'V4_RESET_DONE'; payload?: undefined; id: number };


### PR DESCRIPTION
This change addresses a code health issue in `src/lib/transcription/TranscriptionWorkerClient.ts` where `any` was used for handling worker messages.

Changes:
- Created `src/lib/transcription/WorkerMessages.ts` to define `WorkerMessage` discriminated union and related types (`V4ProcessResult`, `V4TimeoutResult`).
- Updated `TranscriptionWorkerClient.ts` to use `WorkerMessage` in `handleMessage`.
- Refactored `handleMessage` to use direct property access (`data.type`) for proper type narrowing.
- Re-exported types from `TranscriptionWorkerClient.ts` to maintain compatibility with existing consumers (e.g., `App.tsx`).

This improves type safety and maintainability of the worker communication code.

---
*PR created automatically by Jules for task [4847790269385186162](https://jules.google.com/task/4847790269385186162) started by @ysdede*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal transcription message handling structure and consolidated type definitions for improved code maintainability and consistency within the transcription system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->