### PR TITLE
Refactor inline AudioWorkletProcessor to separate file

### DIFF
--- a/src/lib/audio/AudioEngine.ts
+++ b/src/lib/audio/AudioEngine.ts
@@ -2,6 +2,7 @@ import { AudioEngine as IAudioEngine, AudioEngineConfig, AudioSegment, IRingBuff
 import { RingBuffer } from './RingBuffer';
 import { AudioSegmentProcessor, ProcessedSegment } from './AudioSegmentProcessor';
 import { resampleLinear } from './utils';
+import captureProcessorUrl from './capture-processor.ts?worker&url';
 
 /** Duration of the visualization buffer in seconds */
 const VISUALIZATION_BUFFER_DURATION = 30;
@@ -191,86 +192,8 @@ export class AudioEngine implements IAudioEngine {
         });
 
         if (!this.isWorkletInitialized) {
-            const windowDuration = 0.080;
-            const processorCode = `
-                class CaptureProcessor extends AudioWorkletProcessor {
-                    constructor(options) {
-                        super(options);
-                        const opts = options?.processorOptions || {};
-                        this.inputSampleRate = opts.inputSampleRate || 16000;
-                        this.targetSampleRate = opts.targetSampleRate || this.inputSampleRate;
-                        this.ratio = this.inputSampleRate / this.targetSampleRate;
-                        this.bufferSize = Math.round(${windowDuration} * this.inputSampleRate);
-                        this.buffer = new Float32Array(this.bufferSize);
-                        this.index = 0;
-                        this._lastLog = 0;
-                    }
-
-                    _emitChunk() {
-                        let out;
-                        let maxAbs = 0;
-
-                        if (this.targetSampleRate === this.inputSampleRate) {
-                            out = new Float32Array(this.bufferSize);
-                            for (let i = 0; i < this.bufferSize; i++) {
-                                const v = this.buffer[i];
-                                out[i] = v;
-                                const a = v < 0 ? -v : v;
-                                if (a > maxAbs) maxAbs = a;
-                            }
-                        } else {
-                            const outLength = Math.floor(this.bufferSize / this.ratio);
-                            out = new Float32Array(outLength);
-                            for (let i = 0; i < outLength; i++) {
-                                const srcIndex = i * this.ratio;
-                                const srcIndexFloor = Math.floor(srcIndex);
-                                const srcIndexCeil = Math.min(srcIndexFloor + 1, this.bufferSize - 1);
-                                const t = srcIndex - srcIndexFloor;
-                                const v = this.buffer[srcIndexFloor] * (1 - t) + this.buffer[srcIndexCeil] * t;
-                                out[i] = v;
-                                const a = v < 0 ? -v : v;
-                                if (a > maxAbs) maxAbs = a;
-                            }
-                        }
-
-                        this.port.postMessage(
-                            { type: 'audio', samples: out, sampleRate: this.targetSampleRate, maxAbs },
-                            [out.buffer]
-                        );
-                    }
-
-                    process(inputs) {
-                        const input = inputs[0];
-                        if (!input || !input[0]) return true;
-                        
-                        const channelData = input[0];
-                        
-                        // Buffer the data
-                        for (let i = 0; i < channelData.length; i++) {
-                            this.buffer[this.index++] = channelData[i];
-                            
-                            if (this.index >= this.bufferSize) {
-                                this._emitChunk();
-                                this.index = 0;
-                                
-                                // Debug log every ~5 seconds
-                                const now = Date.now();
-                                if (now - this._lastLog > 5000) {
-                                    this.port.postMessage({ type: 'log', message: '[AudioWorklet] Active' });
-                                    this._lastLog = now;
-                                }
-                            }
-                        }
-                        
-                        return true;
-                    }
-                }
-                registerProcessor('capture-processor', CaptureProcessor);
-            `;
-            const blob = new Blob([processorCode], { type: 'application/javascript' });
-            const url = URL.createObjectURL(blob);
             try {
-                await this.audioContext.audioWorklet.addModule(url);
+                await this.audioContext.audioWorklet.addModule(captureProcessorUrl);
                 this.isWorkletInitialized = true;
                 console.log('[AudioEngine] AudioWorklet module loaded');
             } catch (err) {

--- a/src/lib/audio/capture-processor.ts
+++ b/src/lib/audio/capture-processor.ts
@@ -1,18 +1,81 @@
-/**
- * Simple AudioWorkletProcessor for capturing raw audio chunks.
- * Minimal logic to keep latency low.
- */
-class CaptureProcessor extends AudioWorkletProcessor {
-    process(inputs: Float32Array[][], _outputs: Float32Array[][]): boolean {
-        const input = inputs[0];
-        if (!input || input.length === 0) return true;
+const WINDOW_DURATION = 0.080;
 
-        // Use only the first channel (mono)
+class CaptureProcessor extends AudioWorkletProcessor {
+    private inputSampleRate: number;
+    private targetSampleRate: number;
+    private ratio: number;
+    private bufferSize: number;
+    private buffer: Float32Array;
+    private index: number;
+    private _lastLog: number;
+
+    constructor(options: any) {
+        super(options);
+        const opts = options?.processorOptions || {};
+        this.inputSampleRate = opts.inputSampleRate || 16000;
+        this.targetSampleRate = opts.targetSampleRate || this.inputSampleRate;
+        this.ratio = this.inputSampleRate / this.targetSampleRate;
+        this.bufferSize = Math.round(WINDOW_DURATION * this.inputSampleRate);
+        this.buffer = new Float32Array(this.bufferSize);
+        this.index = 0;
+        this._lastLog = 0;
+    }
+
+    _emitChunk() {
+        let out: Float32Array;
+        let maxAbs = 0;
+
+        if (this.targetSampleRate === this.inputSampleRate) {
+            out = new Float32Array(this.bufferSize);
+            for (let i = 0; i < this.bufferSize; i++) {
+                const v = this.buffer[i];
+                out[i] = v;
+                const a = v < 0 ? -v : v;
+                if (a > maxAbs) maxAbs = a;
+            }
+        } else {
+            const outLength = Math.floor(this.bufferSize / this.ratio);
+            out = new Float32Array(outLength);
+            for (let i = 0; i < outLength; i++) {
+                const srcIndex = i * this.ratio;
+                const srcIndexFloor = Math.floor(srcIndex);
+                const srcIndexCeil = Math.min(srcIndexFloor + 1, this.bufferSize - 1);
+                const t = srcIndex - srcIndexFloor;
+                const v = this.buffer[srcIndexFloor] * (1 - t) + this.buffer[srcIndexCeil] * t;
+                out[i] = v;
+                const a = v < 0 ? -v : v;
+                if (a > maxAbs) maxAbs = a;
+            }
+        }
+
+        this.port.postMessage(
+            { type: 'audio', samples: out, sampleRate: this.targetSampleRate, maxAbs },
+            [out.buffer]
+        );
+    }
+
+    process(inputs: Float32Array[][], _outputs: Float32Array[][], _parameters: Record<string, Float32Array>): boolean {
+        const input = inputs[0];
+        if (!input || !input[0]) return true;
+
         const channelData = input[0];
 
-        // Send audio chunk to the main thread
-        // We clone the data to avoid issues with SharedArrayBuffer (if not available)
-        this.port.postMessage(channelData);
+        // Buffer the data
+        for (let i = 0; i < channelData.length; i++) {
+            this.buffer[this.index++] = channelData[i];
+
+            if (this.index >= this.bufferSize) {
+                this._emitChunk();
+                this.index = 0;
+
+                // Debug log every ~5 seconds
+                const now = Date.now();
+                if (now - this._lastLog > 5000) {
+                    this.port.postMessage({ type: 'log', message: '[AudioWorklet] Active' });
+                    this._lastLog = now;
+                }
+            }
+        }
 
         return true;
     }


### PR DESCRIPTION
Refactored the inline `CaptureProcessor` string from `src/lib/audio/AudioEngine.ts` into a dedicated TypeScript file `src/lib/audio/capture-processor.ts`. 

### Changes
- Moved `CaptureProcessor` class and `registerProcessor` call to `src/lib/audio/capture-processor.ts`.
- Replaced interpolated `${windowDuration}` with a constant `WINDOW_DURATION = 0.080` in the new file.
- Updated `AudioEngine.ts` to import the processor using `import captureProcessorUrl from './capture-processor.ts?worker&url';`.
- Updated `AudioEngine.init()` to load the module from the imported URL.

### Verification
- Ran `npm run build` successfully.
- Ran `npm test` - core tests passed. One unrelated flaky test in `TenVADWorkerClient` timed out.
- Verified `AudioEngine` instantiation and worklet loading via a temporary test file.

---
*PR created automatically by Jules for task [17365362216095794719](https://jules.google.com/task/17365362216095794719) started by @ysdede*