### PR TITLE
Fix TenVADWorkerClient race condition logging

### DIFF
--- a/src/lib/vad/TenVADWorkerClient.ts
+++ b/src/lib/vad/TenVADWorkerClient.ts
@@ -125,7 +125,7 @@ export class TenVADWorkerClient {
                 this.pendingPromises.delete(msg.id);
                 p.reject(new Error(msg.payload));
             } else {
-                console.error('[TenVADWorkerClient] Unhandled error:', msg.payload);
+                console.warn(`[TenVADWorkerClient] Received ERROR for unknown/resolved request ${msg.id}:`, msg.payload);
             }
             return;
         }


### PR DESCRIPTION
This PR improves error handling in `TenVADWorkerClient` by downgrading the log level from error to warning when an error response is received for a request that has already been resolved or rejected (e.g., by a timeout or `worker.onerror`). This prevents misleading "Unhandled error" logs during tests where network failures are simulated and race conditions between the worker's error reporting and the main thread's error handling are expected.

---
*PR created automatically by Jules for task [5602149536784966139](https://jules.google.com/task/5602149536784966139) started by @ysdede*