### PR TITLE
chore(rebrand): Keet

### DIFF
--- a/LOCAL_DEV_SETUP.md
+++ b/LOCAL_DEV_SETUP.md
@@ -1,6 +1,6 @@
-# Local Development Setup for boncukjs + parakeet.js
+# Local Development Setup for keet + parakeet.js
 
-This guide explains how to develop boncukjs while simultaneously making changes to the parakeet.js library.
+This guide explains how to develop keet while simultaneously making changes to the parakeet.js library.
 
 ## Prerequisites
 
@@ -8,7 +8,7 @@ Ensure your folder structure looks like this:
 
 ```
 github/ysdede/
-├── boncukjs/          # This project
+├── keet/              # This project
 └── parakeet.js/       # The parakeet.js library source
 ```
 
@@ -17,8 +17,8 @@ github/ysdede/
 ### 1. Install dependencies in both projects
 
 ```bash
-# In boncukjs
-cd boncukjs
+# In keet
+cd keet
 npm install
 
 # In parakeet.js (if not already done)
@@ -82,8 +82,8 @@ When starting the dev server, you'll see:
 ### "LOCAL mode requested but parakeet.js not found"
 
 Make sure the folder structure is correct:
-- `boncukjs` and `parakeet.js` must be sibling directories
-- The path should be `../parakeet.js/src/index.js` relative to boncukjs
+- `keet` and `parakeet.js` must be sibling directories
+- The path should be `../parakeet.js/src/index.js` relative to keet
 
 ### HTTPS Certificate Errors
 
@@ -99,7 +99,7 @@ mkcert -install
 mkcert localhost
 ```
 
-Place `localhost.pem` and `localhost-key.pem` in the boncukjs root.
+Place `localhost.pem` and `localhost-key.pem` in the keet root.
 
 ### Model Loading Issues
 
@@ -109,7 +109,7 @@ If models fail to load in local mode, ensure:
 
 ## Version Compatibility
 
-| boncukjs | parakeet.js | onnxruntime-web |
+| keet | parakeet.js | onnxruntime-web |
 |----------|-------------|-----------------|
 | 0.1.0    | 1.0.1       | 1.22.0-dev.20250409-89f8206ba4 |
 

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -1,6 +1,6 @@
 # Project Memory (Serena / agent context)
 
-This file records high-level decisions and recent work for multi-agent context. **Serena MCP is configured and boncukjs is registered to it.** When an agent has access to Serena MCP, use `mcp_serena_write_memory` to store or sync the points below. Otherwise, agents read this file for context.
+This file records high-level decisions and recent work for multi-agent context. **Serena MCP is configured and keet is registered to it.** When an agent has access to Serena MCP, use `mcp_serena_write_memory` to store or sync the points below. Otherwise, agents read this file for context.
 
 ---
 
@@ -32,7 +32,7 @@ This file records high-level decisions and recent work for multi-agent context. 
 **Serena summary (paste into mcp_serena_write_memory):**
 
 ```
-boncukjs (refactor/streaming-merger): Real-time STT in browser (SolidJS, Parakeet.js). Mel spectrogram uses black-to-red heatmap. Waveform uses fixed gain 4 and clamp to avoid jumps. TenVAD: worker + TenVADWorkerClient + public/wasm. BufferWorker: multi-layer (audio, mel, energyVad, inferenceVad), BufferWorkerClient, fire-and-forget writes, promise reads. Debug panel: LayeredBufferVisualizer (melClient, 8s), auto-scroll finalized sentences, stable VAD/Silero/SNR UI. Vitest pool: forks. Workers: mel, transcription, buffer, tenvad; main thread coordinates.
+keet (refactor/streaming-merger): Real-time STT in browser (SolidJS, Parakeet.js). Mel spectrogram uses black-to-red heatmap. Waveform uses fixed gain 4 and clamp to avoid jumps. TenVAD: worker + TenVADWorkerClient + public/wasm. BufferWorker: multi-layer (audio, mel, energyVad, inferenceVad), BufferWorkerClient, fire-and-forget writes, promise reads. Debug panel: LayeredBufferVisualizer (melClient, 8s), auto-scroll finalized sentences, stable VAD/Silero/SNR UI. Vitest pool: forks. Workers: mel, transcription, buffer, tenvad; main thread coordinates.
 ```
 
 Last updated: 2026-02-07 (after refactor/streaming-merger commits: TenVAD, BufferWorker, Debug panel, mel heatmap, waveform scaling, test config, WindowBuilder comment).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Boncuk.js
+# Keet
 
 Real-time speech-to-text transcription in the browser, powered by [Parakeet.js](https://github.com/ysdede/parakeet.js).
 
@@ -6,7 +6,7 @@ Real-time speech-to-text transcription in the browser, powered by [Parakeet.js](
 
 ## Overview
 
-Boncuk.js is a real-time speech-to-text application built with SolidJS, Vite, and Tailwind CSS. It runs NVIDIA NeMo Parakeet TDT models in the browser via WebGPU/WASM through Parakeet.js, with no backend required.
+Keet is a real-time speech-to-text application built with SolidJS, Vite, and Tailwind CSS. It runs NVIDIA NeMo Parakeet TDT models in the browser via WebGPU/WASM through Parakeet.js, with no backend required.
 
 **Default pipeline (v4):** Utterance-based streaming with a centralized BufferWorker (multi-layer time-aligned buffer), TEN-VAD (WASM) for inference VAD, and HybridVAD (energy-based) for UI. WindowBuilder and UtteranceBasedMerger handle sentence finalization and mature/immature text. Legacy per-utterance (VAD-defined segments) mode is still available. See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for details.
 

--- a/index.html
+++ b/index.html
@@ -4,12 +4,12 @@
   <meta charset="UTF-8" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://huggingface.co https://*.huggingface.co https://*.hf.co https://fonts.googleapis.com https://fonts.gstatic.com; font-src 'self' https://fonts.gstatic.com; frame-src 'self'; img-src 'self' data:; object-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; worker-src 'self' blob:;" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="BoncukJS - Privacy-first real-time transcription. Your audio stays on your device." />
+  <meta name="description" content="Keet - Privacy-first real-time transcription. Your audio stays on your device." />
   <meta name="theme-color" content="#135bec" />
   <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-  <title>Boncuk AI - Real-time Transcription</title>
+  <title>Keet - Real-time Transcription</title>
   
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/metrics/PERFORMANCE_ANALYSIS.md
+++ b/metrics/PERFORMANCE_ANALYSIS.md
@@ -1,7 +1,7 @@
-# Boncukjs Performance Trace Analysis
+# Keet Performance Trace Analysis
 
 **Date:** Feb 7, 2026
-**Trace:** `metrics/trace_boncuk-tracing.json` (Chrome detailed tracing)
+**Trace:** `metrics/trace-keet-tracing.json` (Chrome detailed tracing)
 **Duration:** 93.4s | **Events analyzed:** 1,161,562
 
 ## Process/Thread Map
@@ -198,7 +198,7 @@ The max frame interval of 485.7ms indicates at least one significant stall. Aver
 # Place the trace file in metrics/ directory
 
 # Run the analyzer:
-python metrics/analyze_chrome_trace.py metrics/trace_boncuk-tracing.json
+python metrics/analyze_chrome_trace.py metrics/trace-keet-tracing.json
 
 # For a custom trace file:
 python metrics/analyze_chrome_trace.py path/to/your/trace.json

--- a/metrics/analyze-trace-v2.js
+++ b/metrics/analyze-trace-v2.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-const TRACE_FILE = 'N:\\github\\ysdede\\boncukjs\\metrics\\trace_boncuk-tracing.json';
+const TRACE_FILE = path.resolve(__dirname, 'trace-keet-tracing.json');
 
 try {
     const data = fs.readFileSync(TRACE_FILE, 'utf8');

--- a/metrics/analyze-trace.js
+++ b/metrics/analyze-trace.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-const TRACE_FILE = 'N:\\github\\ysdede\\boncukjs\\metrics\\trace_boncuk-tracing.json';
+const TRACE_FILE = path.resolve(__dirname, 'trace-keet-tracing.json');
 
 try {
     console.log('Reading trace file...');

--- a/metrics/analyze_chrome_trace.py
+++ b/metrics/analyze_chrome_trace.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Comprehensive Chrome trace analyzer for boncukjs.
+Comprehensive Chrome trace analyzer for keet.
 
 Analyzes Chrome performance traces for:
 - Main thread long tasks and rendering pipeline
@@ -15,7 +15,7 @@ Analyzes Chrome performance traces for:
 Usage:
     python analyze_chrome_trace.py [trace_file.json]
 
-If no file is given, defaults to trace_boncuk-tracing.json in the same directory.
+If no file is given, defaults to trace-keet-tracing.json in the same directory.
 Outputs a JSON summary to trace_analysis_summary.json and prints a human-readable report.
 """
 import json
@@ -450,7 +450,7 @@ def print_report(summary):
     ids = s["thread_ids"]
 
     print("\n" + "=" * 75)
-    print("BONCUKJS CHROME TRACE ANALYSIS REPORT")
+    print("KEET CHROME TRACE ANALYSIS REPORT")
     print("=" * 75)
 
     print(f"\nTrace duration: {s['trace_duration_s']:.1f}s  |  Events: {s['total_events']}")
@@ -544,7 +544,7 @@ def main():
         trace_path = sys.argv[1]
     else:
         script_dir = Path(__file__).parent
-        trace_path = str(script_dir / "trace_boncuk-tracing.json")
+        trace_path = str(script_dir / "trace-keet-tracing.json")
 
     if not os.path.exists(trace_path):
         print(f"Error: Trace file not found: {trace_path}")

--- a/metrics/trace_analysis_summary.json
+++ b/metrics/trace_analysis_summary.json
@@ -1,5 +1,5 @@
 {
-  "trace_file": "trace_boncuk-tracing.json",
+  "trace_file": "trace-keet-tracing.json",
   "total_events": 1161562,
   "trace_duration_s": 93.4,
   "thread_ids": {

--- a/metrics/trace_analyze.py
+++ b/metrics/trace_analyze.py
@@ -1,5 +1,5 @@
 import ijson, re, json, sys, traceback, time
-p=r'N:\\github\\ysdede\\boncukjs\\metrics\\trace_boncuk-tracing.json'
+p=r'N:\\github\\ysdede\\keet\\metrics\\trace-keet-tracing.json'
 
 start=time.time()
 thread_name={}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "boncukjs",
+  "name": "keet",
   "version": "1.0.0",
-  "description": "Real-time transcription with parakeet.js",
+  "description": "Keet real-time transcription with parakeet.js",
   "type": "module",
   "scripts": {
     "start": "vite",

--- a/performance-report.md
+++ b/performance-report.md
@@ -1,4 +1,4 @@
-# Boncukjs Performance Profile Report
+# Keet Performance Profile Report
 
 Profile captured with Chrome DevTools MCP (trace with reload).  
 Trace file: `performance-trace.json.gz`

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "BoncukJS",
-    "short_name": "BoncukJS",
+    "name": "Keet",
+    "short_name": "Keet",
     "description": "Privacy-first real-time transcription. Your audio stays on your device.",
     "start_url": "/",
     "display": "standalone",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,5 @@
 /**
- * BoncukJS Service Worker
+ * Keet Service Worker
  * Story 3.1: Offline-first caching strategy
  * 
  * Strategy:
@@ -8,8 +8,8 @@
  * - API/Dynamic: Network-first with fallback
  */
 
-const CACHE_NAME = 'boncukjs-v1';
-const MODEL_CACHE = 'boncukjs-models-v1';
+const CACHE_NAME = 'keet-v1';
+const MODEL_CACHE = 'keet-models-v1';
 
 // App shell files to pre-cache
 const APP_SHELL = [

--- a/src/components/BufferVisualizer.tsx
+++ b/src/components/BufferVisualizer.tsx
@@ -1,7 +1,7 @@
 /**
-"""""""""" * BoncukJS - Buffer Visualizer Component
+"""""""""" * Keet - Buffer Visualizer Component
  * Canvas-based real-time audio waveform visualization.
- * Ported from parakeet-ui (Svelte) to SolidJS.
+ * Ported from legacy UI project (Svelte) to SolidJS.
  */
 
 import { Component, createSignal, onMount, onCleanup, createEffect } from 'solid-js';
@@ -105,7 +105,7 @@ export const BufferVisualizer: Component<BufferVisualizerProps> = (props) => {
         drawSegments(width, canvasHeight, isDarkMode);
       }
 
-      // Draw waveform using Parakeet-UI logic (Etched Mercury Style)
+      // Draw waveform using legacy UI project logic (Etched Mercury Style)
       if (data.length >= 2) {
         // Data is already subsampled to ~400 points (min, max pairs)
         const numPoints = data.length / 2;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 /**
- * BoncukJS v2.0 - Entry Point
+ * Keet v2.0 - Entry Point
  * 
  * Privacy-first, offline-capable real-time transcription.
  */

--- a/src/lib/audio/AudioEngine.ts
+++ b/src/lib/audio/AudioEngine.ts
@@ -77,10 +77,10 @@ export class AudioEngine implements IAudioEngine {
         this.config = {
             sampleRate: 16000,
             bufferDuration: 120,
-            energyThreshold: 0.08, // Match Parakeet-UI 'medium'
-            minSpeechDuration: 240, // Match Parakeet-UI
-            minSilenceDuration: 400, // Match Parakeet-UI
-            maxSegmentDuration: 4.8, // Match Parakeet-UI
+            energyThreshold: 0.08, // Match legacy UI project 'medium'
+            minSpeechDuration: 240, // Match legacy UI project
+            minSilenceDuration: 400, // Match legacy UI project
+            maxSegmentDuration: 4.8, // Match legacy UI project
 
             // Advanced VAD defaults
             lookbackDuration: 0.120,
@@ -329,7 +329,7 @@ export class AudioEngine implements IAudioEngine {
 
     /**
      * Reset buffers and VAD state for a new session while keeping the audio graph.
-     * Aligns visualization + segment timebase to 0, matching parakeet-ui behavior.
+     * Aligns visualization + segment timebase to 0, matching legacy UI project behavior.
      */
     reset(): void {
         // Reset audio/VAD state
@@ -488,7 +488,7 @@ export class AudioEngine implements IAudioEngine {
             }
         }
 
-        // SMA Smoothing (matching Parakeet-UI logic)
+        // SMA Smoothing (matching legacy UI project logic)
         this.energyHistory.push(maxAbs);
         if (this.energyHistory.length > 6) {
             this.energyHistory.shift();
@@ -536,7 +536,7 @@ export class AudioEngine implements IAudioEngine {
         // 3. Handle segments
         if (segments.length > 0) {
             for (const seg of segments) {
-                // Apply lookback and overlap adjustments matching parakeet-ui
+                // Apply lookback and overlap adjustments matching legacy UI project
                 const lookbackDuration = this.config.lookbackDuration ?? 0.120;
                 const startTime = Math.max(0, seg.startTime - lookbackDuration);
 

--- a/src/lib/audio/AudioSegmentProcessor.ts
+++ b/src/lib/audio/AudioSegmentProcessor.ts
@@ -1,6 +1,6 @@
 /**
- * BoncukJS - Audio Segment Processor
- * Ported from parakeet-ui/AudioSegmentProcessor.js
+ * Keet - Audio Segment Processor
+ * Ported from legacy UI project/AudioSegmentProcessor.js
  * 
  * Sophisticated VAD-based segment processor with:
  * - Speech onset detection with lookback

--- a/src/lib/audio/MelWorkerClient.ts
+++ b/src/lib/audio/MelWorkerClient.ts
@@ -1,5 +1,5 @@
 /**
- * BoncukJS - Mel Worker Client
+ * Keet - Mel Worker Client
  * 
  * Manages the mel producer Web Worker lifecycle and provides a promise-based API.
  * 

--- a/src/lib/audio/audioParams.ts
+++ b/src/lib/audio/audioParams.ts
@@ -1,6 +1,6 @@
 /**
- * BoncukJS - Audio Processing Parameters
- * Ported from parakeet-ui/config/audioParams.js
+ * Keet - Audio Processing Parameters
+ * Ported from legacy UI project/config/audioParams.js
  * 
  * Contains all parameters for Voice Activity Detection (VAD) and segment processing.
  * Values are sample-rate-aligned to ensure exact integer sample counts.

--- a/src/lib/audio/energy-calculation.test.ts
+++ b/src/lib/audio/energy-calculation.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for the VAD energy calculation: Peak Amplitude + 6-sample SMA.
  *
  * Matches the logic in AudioEngine (vad-correction-peak-energy fix).
- * parakeet-ui uses peak + 6-sample SMA; RMS was causing all-audio-marked-as-silence.
+ * legacy UI project uses peak + 6-sample SMA; RMS was causing all-audio-marked-as-silence.
  *
  * Run: npm test
  */

--- a/src/lib/audio/mel-e2e.test.ts
+++ b/src/lib/audio/mel-e2e.test.ts
@@ -154,7 +154,7 @@ function fullMelPipeline(audio: Float32Array, nMels: number = 128) {
 
 // ─── Paths ────────────────────────────────────────────────────────────────
 
-// parakeet.js is sibling to boncukjs: __dirname = src/lib/audio, 4 levels up = N:\github\ysdede
+// parakeet.js is sibling to keet: __dirname = src/lib/audio, 4 levels up = N:\github\ysdede
 const PARAKEET_ROOT = join(__dirname, '..', '..', '..', '..', 'parakeet.js');
 const MEL_REFERENCE_PATH = join(PARAKEET_ROOT, 'tests', 'mel_reference.json');
 const WAV_LOCAL_PATH = join(PARAKEET_ROOT, 'examples', 'demo', 'public', 'assets', 'life_Jim.wav');

--- a/src/lib/audio/mel-math.ts
+++ b/src/lib/audio/mel-math.ts
@@ -1,5 +1,5 @@
 /**
- * BoncukJS - Mel Spectrogram Math
+ * Keet - Mel Spectrogram Math
  * 
  * Pure computation functions for mel spectrogram feature extraction.
  * Matches NeMo / onnx-asr / parakeet.js mel.js exactly.

--- a/src/lib/audio/mel.worker.ts
+++ b/src/lib/audio/mel.worker.ts
@@ -1,5 +1,5 @@
 /**
- * BoncukJS - Continuous Mel Producer Worker
+ * Keet - Continuous Mel Producer Worker
  * 
  * Runs in a separate Web Worker thread, continuously computing raw log-mel
  * spectrogram frames as audio arrives. When the inference pipeline needs

--- a/src/lib/audio/types.ts
+++ b/src/lib/audio/types.ts
@@ -35,7 +35,7 @@ export interface AudioEngineConfig {
     /** Preferred device ID (optional) */
     deviceId?: string;
 
-    // Advanced VAD properties matching parakeet-ui
+    // Advanced VAD properties matching legacy UI project
     lookbackDuration?: number;
     overlapDuration?: number;
     speechHangover?: number;

--- a/src/lib/transcription/ModelManager.ts
+++ b/src/lib/transcription/ModelManager.ts
@@ -1,5 +1,5 @@
 /**
- * BoncukJS v2.0 - Model Manager
+ * Keet v2.0 - Model Manager
  * 
  * Handles loading, caching, and managing parakeet.js model lifecycle.
  * Supports WebGPU with WASM fallback.
@@ -17,7 +17,7 @@ import type {
 // Default model configuration (Parakeet TDT 0.6B)
 const DEFAULT_MODEL_ID = 'parakeet-tdt-0.6b-v2';
 
-const CACHE_NAME = 'boncukjs-model-cache-v1';
+const CACHE_NAME = 'keet-model-cache-v1';
 
 export class ModelManager {
   private _state: ModelState = 'unloaded';

--- a/src/lib/transcription/SentenceBoundaryDetector.ts
+++ b/src/lib/transcription/SentenceBoundaryDetector.ts
@@ -5,7 +5,7 @@
  * Provides both NLP-based and heuristic fallback methods for sentence
  * boundary detection in transcription data.
  *
- * Ported from parakeet-ui/src/utils/SentenceBoundaryDetector.js to TypeScript.
+ * Ported from legacy UI project/src/utils/SentenceBoundaryDetector.js to TypeScript.
  */
 
 import winkNLP from 'wink-nlp';

--- a/src/lib/transcription/TokenStreamTranscriber.ts
+++ b/src/lib/transcription/TokenStreamTranscriber.ts
@@ -1,5 +1,5 @@
 /**
- * BoncukJS v3.0 - Token Stream Transcriber
+ * Keet v3.0 - Token Stream Transcriber
  * 
  * Uses LCSPTFAMerger for overlapping window transcription with
  * token-level merging (NeMo LCS + PTFA enhancements).

--- a/src/lib/transcription/TranscriptionService.ts
+++ b/src/lib/transcription/TranscriptionService.ts
@@ -1,5 +1,5 @@
 /**
- * BoncukJS v2.0 - Transcription Service
+ * Keet v2.0 - Transcription Service
  * 
  * High-level service for real-time transcription using parakeet.js
  * StatefulStreamingTranscriber. No complex merging logic required!

--- a/src/lib/transcription/TranscriptionWorkerClient.ts
+++ b/src/lib/transcription/TranscriptionWorkerClient.ts
@@ -1,5 +1,5 @@
 /**
- * BoncukJS v4.0 - Transcription Worker Client
+ * Keet v4.0 - Transcription Worker Client
  * 
  * Main thread bridge to the Transcription Web Worker.
  * Offloads heavy AI transcription to a background thread to prevent UI stutters.

--- a/src/lib/transcription/UtteranceBasedMerger.ts
+++ b/src/lib/transcription/UtteranceBasedMerger.ts
@@ -5,7 +5,7 @@
  * utterance texts. Sentences are detected via winkNLP and finalized once a
  * following sentence appears (proving the previous one is stable).
  *
- * Ported from parakeet-ui/src/UtteranceBasedMerger.js to TypeScript,
+ * Ported from legacy UI project/src/UtteranceBasedMerger.js to TypeScript,
  * with additions for VAD-informed timeout finalization and parakeet.js
  * word timestamp format integration.
  *

--- a/src/lib/transcription/index.ts
+++ b/src/lib/transcription/index.ts
@@ -1,5 +1,5 @@
 /**
- * BoncukJS v3.0 - Transcription Module
+ * Keet v3.0 - Transcription Module
  */
 
 export * from './types';

--- a/src/lib/transcription/transcription.worker.ts
+++ b/src/lib/transcription/transcription.worker.ts
@@ -1,5 +1,5 @@
 /**
- * BoncukJS v4.0 - Transcription Web Worker
+ * Keet v4.0 - Transcription Web Worker
  * 
  * Runs heavy AI inference and text merging in a background thread
  * to prevent UI stuttering on the main thread.

--- a/src/lib/transcription/types.ts
+++ b/src/lib/transcription/types.ts
@@ -1,5 +1,5 @@
 /**
- * BoncukJS v2.0 - Transcription Types
+ * Keet v2.0 - Transcription Types
  */
 
 export type ModelState = 'unloaded' | 'loading' | 'ready' | 'error';

--- a/src/lib/vad/EnergyVAD.ts
+++ b/src/lib/vad/EnergyVAD.ts
@@ -2,7 +2,7 @@ import { EnergyVADConfig, VADResult } from './types';
 
 /**
  * EnergyVAD implements SNR-based Voice Activity Detection with adaptive noise floor tracking.
- * Ported from parakeet-ui's AudioSegmentProcessor for robust speech detection.
+ * Ported from legacy UI project's AudioSegmentProcessor for robust speech detection.
  * 
  * Features:
  * - Adaptive noise floor with fast/slow adaptation rates
@@ -21,12 +21,12 @@ export class EnergyVAD {
     private minSpeechFrames: number;
     private minSilenceFrames: number;
     
-    // Adaptive noise floor tracking (from parakeet-ui)
+    // Adaptive noise floor tracking (from legacy UI project)
     private noiseFloor: number = 0.005; // Initial estimate (lower for better sensitivity)
     private snr: number = 0;
     private silenceDuration: number = 0; // Track silence duration for adaptation rate
 
-    // Adaptation rates (from parakeet-ui/audioParams.js)
+    // Adaptation rates (from legacy UI project/audioParams.js)
     private readonly noiseFloorAdaptationRate = 0.05; // Standard EMA rate
     private readonly fastAdaptationRate = 0.15; // Fast rate for initial calibration
     private readonly minBackgroundDuration = 1.0; // Seconds before switching to slow adaptation
@@ -47,7 +47,7 @@ export class EnergyVAD {
 
     /**
      * Process an audio chunk and return the VAD state.
-     * Uses SNR-based detection with adaptive noise floor (from parakeet-ui).
+     * Uses SNR-based detection with adaptive noise floor (from legacy UI project).
      * @param chunk - Float32Array of mono PCM samples
      */
     process(chunk: Float32Array): VADResult {
@@ -69,7 +69,7 @@ export class EnergyVAD {
         const isAboveEnergyThreshold = energy > this.config.energyThreshold;
         const isSpeech = isAboveSnrThreshold || isAboveEnergyThreshold;
 
-        // 4. Update noise floor adaptively (from parakeet-ui)
+        // 4. Update noise floor adaptively (from legacy UI project)
         if (!isSpeech) {
             // Track silence duration for adaptation rate blending
             this.silenceDuration += chunkDuration;

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -1,5 +1,5 @@
 /**
- * BoncukJS v3.0 - App Store
+ * Keet v3.0 - App Store
  * 
  * Central state management using SolidJS signals.
  * Manages recording state, model status, and transcript.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 /**
- * BoncukJS v2.0 - Type Definitions
+ * Keet v2.0 - Type Definitions
  * 
  * Core types for the transcription application.
  * Based on architecture.md specifications.

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,7 +8,7 @@ import tailwindcss from '@tailwindcss/vite'
 // Check if we should use local parakeet.js
 const useLocalParakeet = process.env.USE_LOCAL_PARAKEET === 'true';
 
-// Path to local parakeet.js (relative to boncukjs)
+// Path to local parakeet.js (relative to keet)
 const localParakeetPath = path.resolve(__dirname, '../parakeet.js');
 
 // Check if local parakeet.js exists
@@ -22,7 +22,7 @@ function readJson(filePath) {
   }
 }
 
-const boncukPkg = readJson(path.resolve(__dirname, 'package.json'));
+const keetPkg = readJson(path.resolve(__dirname, 'package.json'));
 const localParakeetPkg = localParakeetExists ? readJson(path.resolve(localParakeetPath, 'package.json')) : null;
 const npmParakeetPkg = readJson(path.resolve(__dirname, 'node_modules/parakeet.js/package.json'));
 
@@ -35,7 +35,7 @@ if (!parakeetVersion) {
   parakeetSource = localVersion ? 'local (fallback)' : 'unknown';
 }
 
-const onnxVersion = boncukPkg?.dependencies?.['onnxruntime-web'] || 'unknown';
+const onnxVersion = keetPkg?.dependencies?.['onnxruntime-web'] || 'unknown';
 
 if (useLocalParakeet) {
   if (localParakeetExists) {
@@ -44,7 +44,7 @@ if (useLocalParakeet) {
     console.error('LOCAL mode requested but parakeet.js not found at:', localParakeetPath);
     console.error('   Expected folder structure:');
     console.error('   └── github/ysdede/');
-    console.error('       ├── boncukjs/');
+    console.error('       ├── keet/');
     console.error('       └── parakeet.js/');
     process.exit(1);
   }


### PR DESCRIPTION
Align project branding, cache keys, metadata, and internal docs to the new Keet identity so the repository can be migrated without stale BoncukJS/parakeet-ui references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Project rebranded from Boncuk.js to Keet. Updated application title, page metadata, and branding across the interface. Package information, development documentation, build configuration, performance analysis tools, and service worker caching identifiers updated to reflect the new project name throughout the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->