### PR TITLE
fix: use relative paths for GitHub Pages subpath deployment

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -43,10 +43,6 @@ jobs:
           cp -r dist/* deploy_temp/
           touch deploy_temp/.nojekyll
           echo "{\"branch\": \"master\", \"commit\": \"$(git rev-parse --short HEAD)\"}" > deploy_temp/git-info.json
-          # Fix paths for GitHub Pages project site subpath /keet/
-          sed -i 's|"/manifest.json"|"/keet/manifest.json"|g' deploy_temp/index.html
-          sed -i 's|"/sw.js"|"/keet/sw.js"|g' deploy_temp/index.html
-          sed -i 's|href="/icons/|href="/keet/icons/|g' deploy_temp/index.html
 
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v4

--- a/index.html
+++ b/index.html
@@ -28,7 +28,10 @@
   <script>
     if ('serviceWorker' in navigator && location.hostname !== 'localhost') {
       window.addEventListener('load', () => {
-        navigator.serviceWorker.register('/sw.js')
+        // Derive base path from the manifest link (Vite rewrites it with the correct base)
+        var manifestLink = document.querySelector('link[rel="manifest"]');
+        var base = manifestLink ? manifestLink.href.replace(/manifest\.json$/, '') : (location.pathname.replace(/\/[^\/]*$/, '/'));
+        navigator.serviceWorker.register(base + 'sw.js')
           .then((reg) => console.log('[App] SW registered:', reg.scope))
           .catch((err) => console.warn('[App] SW registration failed:', err));
       });

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,26 +2,26 @@
     "name": "Keet",
     "short_name": "Keet",
     "description": "Privacy-first real-time transcription. Your audio stays on your device.",
-    "start_url": "/",
+    "start_url": ".",
     "display": "standalone",
     "background_color": "#0f172a",
     "theme_color": "#3b82f6",
     "orientation": "portrait-primary",
     "icons": [
         {
-            "src": "/icons/icon-192.png",
+            "src": "icons/icon-192.png",
             "sizes": "192x192",
             "type": "image/png",
             "purpose": "any"
         },
         {
-            "src": "/icons/icon-512.png",
+            "src": "icons/icon-512.png",
             "sizes": "512x512",
             "type": "image/png",
             "purpose": "any"
         },
         {
-            "src": "/icons/icon-maskable-512.png",
+            "src": "icons/icon-maskable-512.png",
             "sizes": "512x512",
             "type": "image/png",
             "purpose": "maskable"
@@ -33,6 +33,6 @@
     ],
     "lang": "en",
     "dir": "ltr",
-    "scope": "/",
+    "scope": ".",
     "prefer_related_applications": false
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -11,11 +11,11 @@
 const CACHE_NAME = 'keet-v1';
 const MODEL_CACHE = 'keet-models-v1';
 
-// App shell files to pre-cache
+// App shell files to pre-cache (relative to SW scope)
 const APP_SHELL = [
-    '/',
-    '/index.html',
-    '/manifest.json',
+    './',
+    './index.html',
+    './manifest.json',
 ];
 
 // Model file patterns (cached on-demand)


### PR DESCRIPTION
## Problem

The app deployed at https://ysdede.github.io/keet/ has several console errors:

1. **Service Worker 404** — 
avigator.serviceWorker.register('/sw.js') tries to load from root / instead of /keet/sw.js. The CI sed command used double quotes but the JS used single quotes, so the fix never applied.
2. **Manifest icon 404** — manifest.json has hardcoded /icons/icon-192.png paths. The CI only patched index.html, not the manifest.
3. **SW APP_SHELL 404** — sw.js pre-caches '/', '/index.html', '/manifest.json' which don't exist at the /keet/ subpath.

## Solution

Replace all hardcoded absolute / paths with **relative paths** so they resolve correctly at any base path:

- **index.html**: SW registration derives base from the manifest <link> href (which Vite rewrites correctly with the configured base)
- **manifest.json**: start_url, scope, and icon src changed from / to . / relative
- **sw.js**: APP_SHELL uses './' relative paths
- **deploy-gh-pages.yml**: Removed the fragile sed hacks that patched paths post-build

> **Note**: The ONNX 'Failed to fetch' error is a GitHub Pages platform limitation (no COOP/COEP headers → WebGPU WASM backend can't initialize). This is not addressed by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * App deployment is now more flexible, dynamically adapting to different paths without requiring hardcoded configuration adjustments
  * Service worker registration automatically adjusts based on deployment location

* **Chores**
  * Updated app manifest to use relative paths for resources instead of absolute paths
  * Added productivity and utilities categories to the app manifest

<!-- end of auto-generated comment: release notes by coderabbit.ai -->