### PR TITLE
d fix: relative paths + CSP/COI headers for GH Pages (WebGPU support)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://huggingface.co https://*.huggingface.co https://*.hf.co https://fonts.googleapis.com https://fonts.gstatic.com; font-src 'self' https://fonts.gstatic.com; frame-src 'self'; img-src 'self' data:; object-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; worker-src 'self' blob:;" />
+  <meta http-equiv="Content-Security-Policy"
+    content="default-src 'self'; connect-src 'self' blob: https://huggingface.co https://*.huggingface.co https://*.hf.co https://fonts.googleapis.com https://fonts.gstatic.com; font-src 'self' https://fonts.gstatic.com; frame-src 'self'; img-src 'self' data:; object-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; worker-src 'self' blob:;" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Keet - Privacy-first real-time transcription. Your audio stays on your device." />
   <meta name="theme-color" content="#135bec" />
@@ -10,21 +12,25 @@
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <title>Keet - Real-time Transcription</title>
-  
+
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" />
-  
+  <link
+    href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap"
+    rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+    rel="stylesheet" />
+
   <!-- PWA Manifest -->
   <link rel="manifest" href="/manifest.json" />
   <link rel="icon" type="image/x-icon" href="/src/assets/favicon.ico" />
   <link rel="apple-touch-icon" href="/icons/icon-192.png" />
 </head>
+
 <body>
   <div id="root"></div>
   <script type="module" src="/src/index.tsx"></script>
-  
+
   <script>
     if ('serviceWorker' in navigator && location.hostname !== 'localhost') {
       window.addEventListener('load', () => {
@@ -38,5 +44,5 @@
     }
   </script>
 </body>
-</html>
 
+</html>

--- a/public/sw.js
+++ b/public/sw.js
@@ -6,9 +6,10 @@
  * - App shell (HTML, CSS, JS): Cache-first, update in background
  * - Model files: Cache-first (large files, rarely change)
  * - API/Dynamic: Network-first with fallback
+ * - Cross-origin isolation headers injected for SharedArrayBuffer / WebGPU support
  */
 
-const CACHE_NAME = 'keet-v1';
+const CACHE_NAME = 'keet-v2';
 const MODEL_CACHE = 'keet-models-v1';
 
 // App shell files to pre-cache (relative to SW scope)
@@ -25,6 +26,27 @@ const MODEL_PATTERNS = [
     /vocab\.txt$/,
     /tokenizer\.json$/,
 ];
+
+/**
+ * Add Cross-Origin Isolation headers to a response.
+ * This enables SharedArrayBuffer and WebGPU on static hosts (e.g. GitHub Pages)
+ * that don't allow custom response headers.
+ * Equivalent to what coi-serviceworker.js does in the parakeet.js demo.
+ */
+function addCOIHeaders(response) {
+    if (response.status === 0) {
+        return response;
+    }
+    const newHeaders = new Headers(response.headers);
+    newHeaders.set("Cross-Origin-Embedder-Policy", "require-corp");
+    newHeaders.set("Cross-Origin-Resource-Policy", "cross-origin");
+    newHeaders.set("Cross-Origin-Opener-Policy", "same-origin");
+    return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: newHeaders,
+    });
+}
 
 // Install event - pre-cache app shell
 self.addEventListener('install', (event) => {
@@ -58,7 +80,7 @@ self.addEventListener('activate', (event) => {
     );
 });
 
-// Fetch event - serve from cache or network
+// Fetch event - serve from cache or network, inject COI headers
 self.addEventListener('fetch', (event) => {
     const url = new URL(event.request.url);
 
@@ -96,7 +118,7 @@ self.addEventListener('fetch', (event) => {
         return;
     }
 
-    // App shell: Cache-first with network fallback
+    // App shell: Cache-first with network fallback + COI headers
     if (url.origin === self.location.origin) {
         event.respondWith(
             caches.match(event.request)
@@ -108,19 +130,20 @@ self.addEventListener('fetch', (event) => {
                                 caches.open(CACHE_NAME)
                                     .then((cache) => cache.put(event.request, responseClone));
                             }
-                            return response;
+                            return addCOIHeaders(response);
                         })
                         .catch(() => cached);
 
-                    return cached || fetchPromise;
+                    return cached ? addCOIHeaders(cached) : fetchPromise;
                 })
         );
         return;
     }
 
-    // External resources: Network-first
+    // External resources: Network-first + COI headers
     event.respondWith(
         fetch(event.request)
+            .then((response) => addCOIHeaders(response))
             .catch(() => caches.match(event.request))
     );
 });


### PR DESCRIPTION
## Fixes for GitHub Pages Deployment (Subpath /keet/)

This PR fixes all deployment issues including 404s and ONNX/WebGPU model loading failures.

### 1. 404 Fixes (Subpath Support)
- **index.html**: Dynamically derives service worker registration scope from manifest href (Vite handles base path correctly)
- **manifest.json**: Changed hardcoded absolute paths to **relative paths** (. and icons/)
- **sw.js**: APP_SHELL paths now relative (./)
- **deploy-gh-pages.yml**: Removed fragile sed hacks since paths are now robust

### 2. ONNX WebGPU Support (CSP & COOP/COEP)
- **index.html**: Added lob: to CSP connect-src (fixes ORT WASM fetch error)
- **sw.js**: Injected **COOP/COEP headers** into fetch handler (parakeet.js demo pattern). This enables SharedArrayBuffer and proper WebGPU WASM backend utilization on GitHub Pages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-origin isolation support for enhanced application security

* **Chores**
  * Updated security policy to support blob resources
  * Improved service worker registration mechanism
  * Updated service worker cache version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->