### PR TITLE
Github pages model loading

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: master
+          ref: ${{ github.ref_name }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/public/sw.js
+++ b/public/sw.js
@@ -21,6 +21,7 @@ const APP_SHELL = [
 
 // Model file patterns (cached on-demand)
 const MODEL_PATTERNS = [
+    /\.onnx\.data$/,
     /\.onnx$/,
     /\.bin$/,
     /vocab\.txt$/,


### PR DESCRIPTION
Fixes "Failed to fetch" model loading errors on GitHub Pages by implementing cache recovery and improving service worker caching.

The application encountered `TypeError: Failed to fetch` errors during model loading on GitHub Pages, primarily due to `parakeet.js` attempting to use stale or corrupt blob URLs from its IndexedDB cache. This PR introduces a robust recovery mechanism that, upon a fetch failure, clears the Parakeet IndexedDB cache and retries model loading using direct Hugging Face URLs. It also extends the service worker to cache `.onnx.data` files and updates the GitHub Pages deploy workflow to support deploying from any specified branch.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-1fb63061-7d14-4ae4-a341-d83ba5959636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1fb63061-7d14-4ae4-a341-d83ba5959636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended support for additional model file formats in cache operations.

* **Bug Fixes**
  * Improved model loading reliability with automatic recovery and fallback mechanisms when initial loading fails.
  * Enhanced cache management capabilities.
  * Updated deployment workflow to dynamically reference branches during checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->