### PR TITLE
Optimize TranscriptionWorkerClient to use Transferables

### DIFF
--- a/src/lib/transcription/TranscriptionWorkerClient.ts
+++ b/src/lib/transcription/TranscriptionWorkerClient.ts
@@ -91,11 +91,11 @@ export class TranscriptionWorkerClient {
         }
     }
 
-    private sendRequest(type: string, payload?: any): Promise<any> {
+    private sendRequest(type: string, payload?: any, transfer?: Transferable[]): Promise<any> {
         const id = this.messageId++;
         return new Promise((resolve, reject) => {
             this.pendingPromises.set(id, { resolve, reject });
-            this.worker.postMessage({ type, payload, id });
+            this.worker.postMessage({ type, payload, id }, transfer || []);
         });
     }
 
@@ -117,11 +117,13 @@ export class TranscriptionWorkerClient {
     }
 
     async processChunk(audio: Float32Array): Promise<TranscriptionResult> {
-        return this.sendRequest('PROCESS_CHUNK', audio);
+        // Transfer audio buffer
+        return this.sendRequest('PROCESS_CHUNK', audio, [audio.buffer]);
     }
 
     async processV3Chunk(audio: Float32Array, startTime?: number): Promise<TokenStreamResult> {
-        return this.sendRequest('PROCESS_V3_CHUNK', { audio, startTime });
+        // Transfer audio buffer
+        return this.sendRequest('PROCESS_V3_CHUNK', { audio, startTime }, [audio.buffer]);
     }
 
     /**
@@ -135,13 +137,15 @@ export class TranscriptionWorkerClient {
         startTime?: number,
         overlapSeconds?: number,
     ): Promise<TokenStreamResult> {
+        // Transfer features buffer
         return this.sendRequest('PROCESS_V3_CHUNK_WITH_FEATURES', {
             features, T, melBins, startTime, overlapSeconds,
-        });
+        }, [features.buffer]);
     }
 
     async transcribeSegment(audio: Float32Array): Promise<TranscriptionResult> {
-        return this.sendRequest('TRANSCRIBE_SEGMENT', audio);
+        // Transfer audio buffer
+        return this.sendRequest('TRANSCRIBE_SEGMENT', audio, [audio.buffer]);
     }
 
     async reset(): Promise<void> {
@@ -174,7 +178,8 @@ export class TranscriptionWorkerClient {
         segmentId?: string;
         incrementalCache?: V4IncrementalCache;
     }): Promise<V4ProcessResult> {
-        return this.sendRequest('PROCESS_V4_CHUNK_WITH_FEATURES', params);
+        // Transfer features buffer
+        return this.sendRequest('PROCESS_V4_CHUNK_WITH_FEATURES', params, [params.features.buffer]);
     }
 
     /**


### PR DESCRIPTION
This PR addresses performance issues related to main thread overhead when communicating with the Transcription Worker. By using Transferable objects for large audio and feature buffers, we eliminate the structured cloning cost, significantly reducing the time spent in `HandlePostMessage` on the main thread. This ensures smoother UI performance during active transcription.

---
*PR created automatically by Jules for task [9617886535104194940](https://jules.google.com/task/9617886535104194940) started by @ysdede*