### PR TITLE
fix(audio): prevent buffer detachment in TenVAD client and optimize auto-scroll

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -560,9 +560,11 @@ const App: Component = () => {
             // 2. Forward audio to mel worker (copy, keep chunk for TEN-VAD transfer)
             melClient?.pushAudioCopy(chunk);
 
-            // 3. Forward audio to TEN-VAD worker for inference-based VAD (transfer, no copy)
+            // 3. Forward audio to TEN-VAD worker for inference-based VAD (copy, do NOT transfer)
+            // We use .process() instead of .processTransfer() because AudioEngine still owns 'chunk'
+            // and needs it for ring buffer writing + visualization immediately after this callback.
             if (tenVADClient?.isReady()) {
-              tenVADClient.processTransfer(chunk, chunkOffset);
+              tenVADClient.process(chunk, chunkOffset);
             }
 
             // 4. Update VAD state for UI

--- a/src/components/TranscriptionDisplay.tsx
+++ b/src/components/TranscriptionDisplay.tsx
@@ -1,4 +1,4 @@
-import { Component, Show, createMemo, onMount, onCleanup } from 'solid-js';
+import { Component, Show, createMemo, createEffect } from 'solid-js';
 
 export interface TranscriptionDisplayProps {
     confirmedText: string;
@@ -30,17 +30,15 @@ export const TranscriptionDisplay: Component<TranscriptionDisplayProps> = (props
         (props.confirmedText?.length ?? 0) > 0 || (props.pendingText?.length ?? 0) > 0
     );
 
-    let observer: MutationObserver | undefined;
+    // Auto-scroll when text changes
+    createEffect(() => {
+        // Track text changes
+        props.confirmedText;
+        props.pendingText;
+        // Track recording state (e.g. "Live" indicator appearing)
+        props.isRecording;
 
-    onMount(() => {
-        if (containerRef) {
-            observer = new MutationObserver(scrollToBottom);
-            observer.observe(containerRef, { childList: true, subtree: true });
-        }
-    });
-
-    onCleanup(() => {
-        observer?.disconnect();
+        scrollToBottom();
     });
 
     return (


### PR DESCRIPTION
This PR addresses two issues:
1.  **Audio Engine Crash / Data Loss:** Fixed a critical bug where the audio buffer was being transferred (and thus detached) to the TenVAD worker before the `AudioEngine` had finished using it. This caused the Ring Buffer and visualization to receive empty or invalid data. The fix involves using `.process()` (which copies the buffer) instead of `.processTransfer()` in `src/App.tsx`.
2.  **Transcription Display Performance:** optimized the `TranscriptionDisplay` component by replacing `MutationObserver` with `createEffect`. This ensures that auto-scrolling is triggered only by meaningful state changes (text updates or recording status) rather than arbitrary DOM mutations, improving performance and simplifying the component logic.


---
*PR created automatically by Jules for task [11369990206949326258](https://jules.google.com/task/11369990206949326258) started by @ysdede*