### PR TITLE
fix: refactor TranscriptionDisplay and fix buffer safety in App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -560,9 +560,11 @@ const App: Component = () => {
             // 2. Forward audio to mel worker (copy, keep chunk for TEN-VAD transfer)
             melClient?.pushAudioCopy(chunk);
 
-            // 3. Forward audio to TEN-VAD worker for inference-based VAD (transfer, no copy)
+            // 3. Forward audio to TEN-VAD worker for inference-based VAD (copy + transfer)
+            // Note: We use .process() (which copies) instead of .processTransfer() because
+            // AudioEngine requires the original 'chunk' buffer for visualization/ring-buffer.
             if (tenVADClient?.isReady()) {
-              tenVADClient.processTransfer(chunk, chunkOffset);
+              tenVADClient.process(chunk, chunkOffset);
             }
 
             // 4. Update VAD state for UI

--- a/src/components/TranscriptionDisplay.tsx
+++ b/src/components/TranscriptionDisplay.tsx
@@ -1,4 +1,4 @@
-import { Component, Show, createMemo, onMount, onCleanup } from 'solid-js';
+import { Component, Show, createMemo, onMount, createEffect, onCleanup } from 'solid-js';
 
 export interface TranscriptionDisplayProps {
     confirmedText: string;
@@ -30,17 +30,14 @@ export const TranscriptionDisplay: Component<TranscriptionDisplayProps> = (props
         (props.confirmedText?.length ?? 0) > 0 || (props.pendingText?.length ?? 0) > 0
     );
 
-    let observer: MutationObserver | undefined;
+    // Auto-scroll when text changes
+    createEffect(() => {
+        // Dependencies: these will trigger the effect when changed
+        props.confirmedText;
+        props.pendingText;
 
-    onMount(() => {
-        if (containerRef) {
-            observer = new MutationObserver(scrollToBottom);
-            observer.observe(containerRef, { childList: true, subtree: true });
-        }
-    });
-
-    onCleanup(() => {
-        observer?.disconnect();
+        // Schedule scroll
+        scrollToBottom();
     });
 
     return (
@@ -119,4 +116,3 @@ export const TranscriptionDisplay: Component<TranscriptionDisplayProps> = (props
 };
 
 export default TranscriptionDisplay;
-


### PR DESCRIPTION
This PR addresses two issues:
1.  **Performance/Stability in UI:** `TranscriptionDisplay` was using `MutationObserver` to trigger auto-scroll. This has been replaced with a SolidJS `createEffect` on `confirmedText` and `pendingText` props, which is more efficient and idiomatic. The `requestAnimationFrame` throttling for the actual scroll action is preserved.
2.  **Critical Bug in Audio Pipeline:** In `App.tsx`, the audio chunk buffer was being transferred to the `TenVADWorker` via `processTransfer`. This detached the buffer from the main thread, causing `AudioEngine` (which owns the buffer and uses it for visualization and ring-buffer writing) to potentially access an invalid/empty buffer. The call was changed to `process`, which internally copies the buffer before transferring the copy, ensuring the original buffer remains valid for `AudioEngine`.

---
*PR created automatically by Jules for task [3897330223291647915](https://jules.google.com/task/3897330223291647915) started by @ysdede*