### PR TITLE
Improve TenVADWorkerClient error handling for race conditions

### DIFF
--- a/src/lib/vad/TenVADWorkerClient.ts
+++ b/src/lib/vad/TenVADWorkerClient.ts
@@ -125,7 +125,7 @@ export class TenVADWorkerClient {
                 this.pendingPromises.delete(msg.id);
                 p.reject(new Error(msg.payload));
             } else {
-                console.error('[TenVADWorkerClient] Unhandled error:', msg.payload);
+                console.warn('[TenVADWorkerClient] Received ERROR for non-pending request:', msg.payload);
             }
             return;
         }


### PR DESCRIPTION
Downgraded the log level from error to warn when receiving an ERROR message for a non-pending request in `TenVADWorkerClient`. This addresses a race condition where `worker.onerror` or a duplicate message might have already handled the promise rejection, preventing misleading error logs in tests and production. Verified with `npm test`.

---
*PR created automatically by Jules for task [13482741029677555389](https://jules.google.com/task/13482741029677555389) started by @ysdede*