### PR TITLE
perf: Implement zero-copy audio transfer and optimize scroll

### DIFF
--- a/src/lib/transcription/TranscriptionWorkerClient.ts
+++ b/src/lib/transcription/TranscriptionWorkerClient.ts
@@ -91,11 +91,11 @@ export class TranscriptionWorkerClient {
         }
     }
 
-    private sendRequest(type: string, payload?: any): Promise<any> {
+    private sendRequest(type: string, payload?: any, transfer: Transferable[] = []): Promise<any> {
         const id = this.messageId++;
         return new Promise((resolve, reject) => {
             this.pendingPromises.set(id, { resolve, reject });
-            this.worker.postMessage({ type, payload, id });
+            this.worker.postMessage({ type, payload, id }, transfer);
         });
     }
 
@@ -121,7 +121,7 @@ export class TranscriptionWorkerClient {
     }
 
     async processV3Chunk(audio: Float32Array, startTime?: number): Promise<TokenStreamResult> {
-        return this.sendRequest('PROCESS_V3_CHUNK', { audio, startTime });
+        return this.sendRequest('PROCESS_V3_CHUNK', { audio, startTime }, [audio.buffer]);
     }
 
     /**
@@ -137,7 +137,7 @@ export class TranscriptionWorkerClient {
     ): Promise<TokenStreamResult> {
         return this.sendRequest('PROCESS_V3_CHUNK_WITH_FEATURES', {
             features, T, melBins, startTime, overlapSeconds,
-        });
+        }, [features.buffer]);
     }
 
     async transcribeSegment(audio: Float32Array): Promise<TranscriptionResult> {
@@ -174,7 +174,7 @@ export class TranscriptionWorkerClient {
         segmentId?: string;
         incrementalCache?: V4IncrementalCache;
     }): Promise<V4ProcessResult> {
-        return this.sendRequest('PROCESS_V4_CHUNK_WITH_FEATURES', params);
+        return this.sendRequest('PROCESS_V4_CHUNK_WITH_FEATURES', params, [params.features.buffer]);
     }
 
     /**


### PR DESCRIPTION
This change addresses two performance issues:
1.  **Issue 4 (Worker Message Overhead):**
    *   Reordered `AudioEngine.ts` to call `audioChunkCallbacks` *after* internal processing (RingBuffer write, VAD, Vis). This allows subscribers (like TenVAD worker) to transfer the audio buffer without detaching it before the engine uses it.
    *   Updated `TranscriptionWorkerClient.ts` to support transferring buffers (`Transferable[]`) in `sendRequest`.
    *   Updated `processV4ChunkWithFeatures`, `processV3ChunkWithFeatures`, and `processV3Chunk` to transfer large buffers (`features`, `audio`) instead of copying them.
2.  **Issue 2 (Scroll Reflows):**
    *   Optimized `TranscriptionDisplay.tsx` by adding a 50ms debounce to `scrollToBottom` and explicitly disabling `characterData` observation in `MutationObserver`. This prevents excessive layout thrashing during rapid text streaming.

Verified with `mel-e2e.test.ts` and a temporary reproduction test for `AudioEngine`.

---
*PR created automatically by Jules for task [13074619647761767215](https://jules.google.com/task/13074619647761767215) started by @ysdede*