### PR TITLE
Optimize streaming pipeline to cut overhead and improve profiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ public/models/
 performance-trace.json.gz
 conductor/
 *.gz
+traces/

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -1,0 +1,53 @@
+# Trace Analyzer Toolkit
+
+## Primary Tool
+
+`metrics/trace_ultimate.py` is the primary analyzer for Chrome traces.
+
+### Features
+
+- Thread/process discovery for renderer/main/compositor/audio/workers
+- Worker URL mapping via `TracingSessionIdForWorker`
+- Per-thread CPU + long-task summaries
+- GC breakdown by thread
+- Message cadence (`HandlePostMessage`)
+- Main render-loop rates (`FireAnimationFrame`, `PageAnimator::serviceScriptedAnimations`)
+- AudioWorklet interval stats
+- Ranked bottlenecks with measured evidence
+- Baseline comparison mode
+
+## Usage
+
+### Baseline
+
+```bash
+python metrics/trace_ultimate.py traces/Trace-20260217T235732.json \
+  --output-json traces/baseline.ultimate.json \
+  --output-md traces/baseline.ultimate.md
+```
+
+### Compare After vs Baseline
+
+```bash
+python metrics/trace_ultimate.py traces/Trace-after.json \
+  --baseline-json traces/baseline.ultimate.json \
+  --output-json traces/after.ultimate.json \
+  --output-md traces/after.ultimate.md
+```
+
+## CLI Arguments
+
+- Positional: `trace_path`
+- Optional: `--output-json <path>`
+- Optional: `--output-md <path>`
+- Optional: `--baseline-json <path>`
+- Optional: `--window-sec <int>` (reserved, default `30`)
+- Optional: `--long-task-ms <int>` (default `50`)
+- Optional: `--top <int>` (default `15`)
+
+## Backward Compatibility
+
+`metrics/analyze_chrome_trace.py` now delegates to `trace_ultimate.py` while preserving legacy defaults:
+
+- Default input: `metrics/trace-keet-tracing.json`
+- Default output: `<trace-dir>/trace_analysis_summary.json`

--- a/metrics/analyze_chrome_trace.py
+++ b/metrics/analyze_chrome_trace.py
@@ -1,648 +1,73 @@
 #!/usr/bin/env python3
 """
-Comprehensive Chrome trace analyzer for keet.
+Backward-compatible wrapper around metrics/trace_ultimate.py.
 
-Analyzes Chrome performance traces for:
-- Main thread long tasks and rendering pipeline
-- Web Worker activity and GC pressure
-- WebGPU command patterns and stalls
-- AudioWorklet timing precision and jitter
-- WASM compilation overhead
-- Worker message passing overhead
-- Frame rate and rendering analysis
-- JS function call hotspots
+Legacy behavior:
+  python analyze_chrome_trace.py [trace_file]
 
-Usage:
-    python analyze_chrome_trace.py [trace_file.json]
-
-If no file is given, defaults to trace-keet-tracing.json in the same directory.
-Outputs a JSON summary to trace_analysis_summary.json and prints a human-readable report.
+This wrapper keeps the old default filename and output filename conventions:
+- default input: trace-keet-tracing.json (in metrics dir)
+- output JSON: trace_analysis_summary.json (next to trace file)
 """
+
+from __future__ import annotations
+
+import argparse
 import json
-import os
-import sys
-import statistics
-from collections import defaultdict
 from pathlib import Path
 
-
-def load_trace(path):
-    print(f"Loading trace file: {path}")
-    with open(path, "r", encoding="utf-8") as f:
-        data = json.load(f)
-    events = data.get("traceEvents", data if isinstance(data, list) else [])
-    print(f"Loaded {len(events)} events")
-    return events
-
-
-def build_maps(events):
-    """Build PID -> process name and (PID, TID) -> thread name mappings."""
-    pid_names = {}
-    tid_names = {}
-    for e in events:
-        if e.get("ph") != "M":
-            continue
-        args = e.get("args", {})
-        if e.get("name") == "process_name":
-            pid_names[e["pid"]] = args.get("name", "")
-        elif e.get("name") == "thread_name":
-            tid_names[(e["pid"], e["tid"])] = args.get("name", "")
-    return pid_names, tid_names
-
-
-def identify_renderer(pid_names, tid_names):
-    """Find the main renderer PID and key thread IDs."""
-    renderer_pids = [pid for pid, name in pid_names.items() if name == "Renderer"]
-    gpu_pid = next((pid for pid, name in pid_names.items() if name == "GPU Process"), None)
-    audio_service_pid = next(
-        (pid for pid, name in pid_names.items() if "audio" in name.lower()), None
-    )
-
-    # The main renderer is the one with the most threads (workers, AudioWorklet, etc.)
-    thread_counts = defaultdict(int)
-    for (pid, _tid), _name in tid_names.items():
-        if pid in renderer_pids:
-            thread_counts[pid] += 1
-    if thread_counts:
-        renderer_pid = max(thread_counts, key=thread_counts.get)
-    elif renderer_pids:
-        renderer_pid = renderer_pids[0]
-    else:
-        renderer_pid = None
-
-    main_tid = None
-    compositor_tid = None
-    audio_worklet_tid = None
-    worker_tids = []
-
-    if renderer_pid:
-        for (pid, tid), name in tid_names.items():
-            if pid != renderer_pid:
-                continue
-            if name == "CrRendererMain":
-                main_tid = tid
-            elif name == "Compositor":
-                compositor_tid = tid
-            elif "AudioWorklet" in name:
-                audio_worklet_tid = tid
-            elif name == "DedicatedWorker thread":
-                worker_tids.append(tid)
-
-    return {
-        "renderer_pid": renderer_pid,
-        "main_tid": main_tid,
-        "compositor_tid": compositor_tid,
-        "audio_worklet_tid": audio_worklet_tid,
-        "worker_tids": sorted(worker_tids),
-        "gpu_pid": gpu_pid,
-        "audio_service_pid": audio_service_pid,
-    }
-
-
-def analyze_thread_events(events, pid, tid, label="Thread"):
-    """Analyze all X (complete) events on a specific thread."""
-    thread_events = [
-        e for e in events
-        if e.get("pid") == pid and e.get("tid") == tid and e.get("ph") == "X"
-    ]
-    if not thread_events:
-        return {"label": label, "event_count": 0, "total_dur_ms": 0, "top_names": []}
-
-    total_dur = sum(e.get("dur", 0) for e in thread_events)
-    name_stats = defaultdict(lambda: {"count": 0, "total": 0, "max": 0})
-    for e in thread_events:
-        n = e.get("name", "?")
-        d = e.get("dur", 0)
-        s = name_stats[n]
-        s["count"] += 1
-        s["total"] += d
-        s["max"] = max(s["max"], d)
-
-    top_names = sorted(name_stats.items(), key=lambda x: -x[1]["total"])[:15]
-
-    return {
-        "label": label,
-        "event_count": len(thread_events),
-        "total_dur_ms": round(total_dur / 1000, 1),
-        "top_names": [
-            {
-                "name": n,
-                "count": s["count"],
-                "total_ms": round(s["total"] / 1000, 1),
-                "max_ms": round(s["max"] / 1000, 2),
-            }
-            for n, s in top_names
-        ],
-    }
-
-
-def analyze_long_tasks(events, pid, tid, threshold_us=50000):
-    """Find tasks exceeding the threshold on a specific thread."""
-    long = []
-    for e in events:
-        if (
-            e.get("pid") == pid
-            and e.get("tid") == tid
-            and e.get("ph") == "X"
-            and e.get("dur", 0) > threshold_us
-        ):
-            long.append(e)
-    long.sort(key=lambda x: -x.get("dur", 0))
-    return [
-        {
-            "dur_ms": round(e["dur"] / 1000, 1),
-            "name": e.get("name", "?"),
-            "cat": e.get("cat", "?"),
-        }
-        for e in long[:25]
-    ]
-
-
-def analyze_gc(events, pid, tids=None):
-    """Analyze garbage collection events."""
-    gc_events = []
-    for e in events:
-        if e.get("pid") != pid or e.get("ph") != "X":
-            continue
-        if tids and e.get("tid") not in tids:
-            continue
-        name = e.get("name", "")
-        if "GC" in name or "gc" in e.get("cat", ""):
-            gc_events.append(e)
-
-    if not gc_events:
-        return {"count": 0, "total_ms": 0, "by_thread": {}}
-
-    by_thread = defaultdict(lambda: {"count": 0, "total": 0, "max": 0})
-    for e in gc_events:
-        tid = e.get("tid", 0)
-        d = e.get("dur", 0)
-        s = by_thread[tid]
-        s["count"] += 1
-        s["total"] += d
-        s["max"] = max(s["max"], d)
-
-    return {
-        "count": len(gc_events),
-        "total_ms": round(sum(e.get("dur", 0) for e in gc_events) / 1000, 1),
-        "by_thread": {
-            str(tid): {
-                "count": s["count"],
-                "total_ms": round(s["total"] / 1000, 1),
-                "max_ms": round(s["max"] / 1000, 2),
-            }
-            for tid, s in by_thread.items()
-        },
-    }
-
-
-def analyze_webgpu(events, gpu_pid):
-    """Analyze WebGPU command patterns."""
-    webgpu = sorted(
-        [
-            e for e in events
-            if e.get("pid") == gpu_pid
-            and e.get("ph") == "X"
-            and "WebGPU" in e.get("name", "")
-        ],
-        key=lambda e: e["ts"],
-    )
-    if not webgpu:
-        return {"count": 0}
-
-    durs = [e["dur"] for e in webgpu]
-    ts_list = [e["ts"] for e in webgpu]
-    n = len(durs)
-    dur_sorted = sorted(durs)
-
-    # Detect bursts (gaps < 500us)
-    gaps = [ts_list[i + 1] - ts_list[i] for i in range(len(ts_list) - 1)]
-    burst_lens = []
-    cur = 1
-    for g in gaps:
-        if g < 500:
-            cur += 1
-        else:
-            if cur > 5:
-                burst_lens.append(cur)
-            cur = 1
-    if cur > 5:
-        burst_lens.append(cur)
-
-    high_dur = [e for e in webgpu if e["dur"] > 5000]
-
-    return {
-        "count": len(webgpu),
-        "time_span_s": round((ts_list[-1] - ts_list[0]) / 1e6, 1),
-        "rate_per_s": round(len(webgpu) / max((ts_list[-1] - ts_list[0]) / 1e6, 0.001), 1),
-        "total_ms": round(sum(durs) / 1000, 1),
-        "percentiles": {
-            "p50_us": dur_sorted[n // 2],
-            "p90_us": dur_sorted[int(n * 0.9)],
-            "p95_us": dur_sorted[int(n * 0.95)],
-            "p99_us": dur_sorted[int(n * 0.99)],
-            "max_us": dur_sorted[-1],
-        },
-        "histogram": {
-            "lt_100us": sum(1 for d in durs if d < 100),
-            "100_500us": sum(1 for d in durs if 100 <= d < 500),
-            "500_1ms": sum(1 for d in durs if 500 <= d < 1000),
-            "1_5ms": sum(1 for d in durs if 1000 <= d < 5000),
-            "5_50ms": sum(1 for d in durs if 5000 <= d < 50000),
-            "gt_50ms": sum(1 for d in durs if d >= 50000),
-        },
-        "burst_count": len(burst_lens),
-        "burst_sizes": {
-            "min": min(burst_lens) if burst_lens else 0,
-            "max": max(burst_lens) if burst_lens else 0,
-            "avg": round(statistics.mean(burst_lens), 1) if burst_lens else 0,
-        },
-        "high_dur_gt5ms": len(high_dur),
-    }
-
-
-def analyze_audioworklet(events, pid, tid):
-    """Analyze AudioWorklet scheduling precision."""
-    if tid is None:
-        return {"note": "No AudioWorklet thread found"}
-
-    runs = sorted(
-        [
-            e for e in events
-            if e.get("pid") == pid
-            and e.get("tid") == tid
-            and e.get("ph") == "X"
-            and e.get("name") == "ThreadControllerImpl::RunTask"
-        ],
-        key=lambda e: e["ts"],
-    )
-    if not runs:
-        return {"count": 0}
-
-    durs = [e["dur"] for e in runs]
-    ts_list = [e["ts"] for e in runs]
-    intervals = [ts_list[i + 1] - ts_list[i] for i in range(len(ts_list) - 1)]
-
-    dur_sorted = sorted(durs)
-    n = len(durs)
-
-    # Expected interval for 128 samples @ 48kHz = 2667us
-    expected_128 = 2666.67
-    # Expected interval for 480 samples @ 48kHz = 10000us
-    expected_480 = 10000.0
-
-    avg_interval = statistics.mean(intervals) if intervals else 0
-    # Auto-detect buffer size
-    if avg_interval > 8000:
-        expected = expected_480
-        buffer_samples = round(avg_interval * 48)  # approximate
-    else:
-        expected = expected_128
-        buffer_samples = 128
-
-    jitter = [abs(i - expected) for i in intervals] if intervals else []
-
-    return {
-        "callback_count": len(runs),
-        "estimated_buffer_samples": buffer_samples,
-        "task_duration": {
-            "avg_us": round(statistics.mean(durs)),
-            "max_us": max(durs),
-            "p99_us": dur_sorted[int(n * 0.99)] if n > 100 else dur_sorted[-1],
-        },
-        "interval": {
-            "avg_us": round(statistics.mean(intervals)) if intervals else 0,
-            "max_us": max(intervals) if intervals else 0,
-            "stddev_us": round(statistics.stdev(intervals)) if len(intervals) > 1 else 0,
-        },
-        "jitter_vs_expected": {
-            "expected_us": round(expected),
-            "avg_us": round(statistics.mean(jitter)) if jitter else 0,
-            "max_us": round(max(jitter)) if jitter else 0,
-            "p99_us": round(sorted(jitter)[int(len(jitter) * 0.99)]) if len(jitter) > 100 else round(max(jitter)) if jitter else 0,
-        },
-        "late_callbacks_gt_expected_x1_5": sum(1 for i in intervals if i > expected * 1.5),
-        "very_late_callbacks_gt_expected_x3": sum(1 for i in intervals if i > expected * 3),
-    }
-
-
-def analyze_worker_inference(events, pid, tid):
-    """Analyze inference pattern on a specific worker."""
-    js_calls = sorted(
-        [
-            e for e in events
-            if e.get("pid") == pid
-            and e.get("tid") == tid
-            and e.get("ph") == "X"
-            and e.get("name") == "v8.callFunction"
-        ],
-        key=lambda e: e["ts"],
-    )
-    if not js_calls:
-        return {"js_calls": 0}
-
-    durs = [e["dur"] for e in js_calls]
-    ts_list = [e["ts"] for e in js_calls]
-    intervals = [ts_list[i + 1] - ts_list[i] for i in range(len(ts_list) - 1)]
-
-    return {
-        "js_calls": len(js_calls),
-        "duration_ms": {
-            "avg": round(statistics.mean(durs) / 1000, 2),
-            "max": round(max(durs) / 1000, 2),
-            "total": round(sum(durs) / 1000, 1),
-        },
-        "interval_ms": {
-            "avg": round(statistics.mean(intervals) / 1000, 1) if intervals else 0,
-            "max": round(max(intervals) / 1000, 1) if intervals else 0,
-            "p50": round(sorted(intervals)[len(intervals) // 2] / 1000, 1) if intervals else 0,
-        },
-    }
-
-
-def analyze_message_passing(events, pid):
-    """Analyze SerializedScriptValueFactory create/deserialize overhead."""
-    create_by_tid = defaultdict(lambda: {"count": 0, "total": 0})
-    deser_by_tid = defaultdict(lambda: {"count": 0, "total": 0})
-
-    for e in events:
-        if e.get("pid") != pid or e.get("ph") != "X":
-            continue
-        name = e.get("name", "")
-        tid = e.get("tid", 0)
-        dur = e.get("dur", 0)
-        if "SerializedScriptValueFactory::create" in name:
-            s = create_by_tid[tid]
-            s["count"] += 1
-            s["total"] += dur
-        elif "SerializedScriptValueFactory::deserialize" in name:
-            s = deser_by_tid[tid]
-            s["count"] += 1
-            s["total"] += dur
-
-    all_tids = sorted(set(list(create_by_tid.keys()) + list(deser_by_tid.keys())))
-    result = {}
-    for tid in all_tids:
-        c = create_by_tid[tid]
-        d = deser_by_tid[tid]
-        result[str(tid)] = {
-            "serialize_ms": round(c["total"] / 1000, 1),
-            "serialize_count": c["count"],
-            "deserialize_ms": round(d["total"] / 1000, 1),
-            "deserialize_count": d["count"],
-        }
-    return result
-
-
-def analyze_wasm(events):
-    """Find WASM-related events."""
-    wasm = [
-        e for e in events
-        if e.get("ph") == "X" and "wasm" in str(e.get("args", {})).lower()
-    ]
-    wasm.sort(key=lambda x: -x.get("dur", 0))
-    return [
-        {
-            "dur_ms": round(e.get("dur", 0) / 1000, 2),
-            "name": e.get("name", "?"),
-            "tid": e.get("tid"),
-            "src_func": e.get("args", {}).get("src_func", "")[:80],
-        }
-        for e in wasm[:15]
-    ]
-
-
-def analyze_frames(events, pid, compositor_tid):
-    """Analyze frame pacing from compositor draw events."""
-    draws = sorted(
-        [
-            e for e in events
-            if e.get("pid") == pid
-            and e.get("tid") == compositor_tid
-            and e.get("ph") == "X"
-            and e.get("name") == "ProxyImpl::ScheduledActionDraw"
-        ],
-        key=lambda e: e["ts"],
-    )
-    if len(draws) < 2:
-        return {"draw_count": len(draws)}
-
-    ts_list = [e["ts"] for e in draws]
-    intervals = [ts_list[i + 1] - ts_list[i] for i in range(len(ts_list) - 1)]
-    avg_interval = statistics.mean(intervals)
-
-    return {
-        "draw_count": len(draws),
-        "effective_fps": round(1e6 / avg_interval, 1) if avg_interval > 0 else 0,
-        "interval_ms": {
-            "avg": round(avg_interval / 1000, 1),
-            "max": round(max(intervals) / 1000, 1),
-            "min": round(min(intervals) / 1000, 1),
-        },
-        "janky_frames_gt_2x_avg": sum(1 for i in intervals if i > 2 * avg_interval),
-        "total_frames": len(draws),
-    }
-
-
-def print_report(summary):
-    """Print a human-readable report from the summary dict."""
-    s = summary
-    ids = s["thread_ids"]
-
-    print("\n" + "=" * 75)
-    print("KEET CHROME TRACE ANALYSIS REPORT")
-    print("=" * 75)
-
-    print(f"\nTrace duration: {s['trace_duration_s']:.1f}s  |  Events: {s['total_events']}")
-
-    print("\n--- Process/Thread Map ---")
-    print(f"  Renderer PID: {ids['renderer_pid']}")
-    print(f"  Main Thread TID: {ids['main_tid']}")
-    print(f"  Compositor TID: {ids['compositor_tid']}")
-    print(f"  AudioWorklet TID: {ids['audio_worklet_tid']}")
-    print(f"  Worker TIDs: {ids['worker_tids']}")
-    print(f"  GPU Process PID: {ids['gpu_pid']}")
-
-    print("\n--- Thread CPU Time ---")
-    for info in s["thread_activity"]:
-        print(f"  {info['label']:40s}: {info['total_dur_ms']:8.1f}ms")
-
-    # Main thread
-    mt = s["main_thread"]
-    print(f"\n--- Main Thread ({mt['event_count']} events, {mt['total_dur_ms']}ms) ---")
-    for item in mt["top_names"][:15]:
-        print(f"  {item['total_ms']:8.1f}ms  {item['max_ms']:6.1f}ms max  {item['count']:6d}x  {item['name']}")
-
-    # Long tasks
-    lt = s["main_thread_long_tasks"]
-    print(f"\n--- Main Thread Long Tasks (>50ms): {len(lt)} ---")
-    for t in lt[:10]:
-        print(f"  {t['dur_ms']:8.1f}ms  {t['name']}  cat={t['cat']}")
-
-    # Workers
-    for w in s["workers"]:
-        label = w["label"]
-        print(f"\n--- {label} ({w['event_count']} events, {w['total_dur_ms']}ms) ---")
-        for item in w["top_names"][:8]:
-            print(f"  {item['total_ms']:8.1f}ms  {item['max_ms']:6.1f}ms max  {item['count']:5d}x  {item['name']}")
-
-    # GC
-    gc = s["gc"]
-    print(f"\n--- Garbage Collection: {gc['count']} events, {gc['total_ms']}ms ---")
-    for tid_str, info in gc["by_thread"].items():
-        print(f"  tid={tid_str}: {info['count']}x  {info['total_ms']}ms  max={info['max_ms']}ms")
-
-    # WebGPU
-    wg = s["webgpu"]
-    print(f"\n--- WebGPU: {wg['count']} commands, {wg.get('total_ms', 0)}ms GPU time ---")
-    if wg["count"] > 0:
-        p = wg["percentiles"]
-        print(f"  Rate: {wg['rate_per_s']}/s  Bursts: {wg['burst_count']}")
-        print(f"  P50={p['p50_us']}us  P90={p['p90_us']}us  P95={p['p95_us']}us  P99={p['p99_us']}us  Max={p['max_us']}us")
-        print(f"  Commands >5ms: {wg['high_dur_gt5ms']}")
-
-    # AudioWorklet
-    aw = s["audioworklet"]
-    print(f"\n--- AudioWorklet ---")
-    if aw.get("callback_count", 0) > 0:
-        print(f"  Callbacks: {aw['callback_count']}  Buffer: ~{aw['estimated_buffer_samples']} samples")
-        td = aw["task_duration"]
-        print(f"  Task dur: avg={td['avg_us']}us  max={td['max_us']}us  P99={td['p99_us']}us")
-        iv = aw["interval"]
-        print(f"  Interval: avg={iv['avg_us']}us  max={iv['max_us']}us  stddev={iv['stddev_us']}us")
-        j = aw["jitter_vs_expected"]
-        print(f"  Jitter vs {j['expected_us']}us: avg={j['avg_us']}us  max={j['max_us']}us")
-        print(f"  Late (>1.5x): {aw['late_callbacks_gt_expected_x1_5']}  Very late (>3x): {aw['very_late_callbacks_gt_expected_x3']}")
-
-    # Frames
-    fr = s["frames"]
-    print(f"\n--- Rendering ---")
-    print(f"  Draws: {fr['draw_count']}  FPS: {fr.get('effective_fps', '?')}")
-    if "interval_ms" in fr:
-        iv = fr["interval_ms"]
-        print(f"  Frame interval: avg={iv['avg']}ms  max={iv['max']}ms  min={iv['min']}ms")
-        print(f"  Janky frames: {fr['janky_frames_gt_2x_avg']}")
-
-    # WASM
-    print(f"\n--- WASM: {len(s['wasm'])} events ---")
-    for w in s["wasm"][:5]:
-        print(f"  {w['dur_ms']}ms  {w['name']}  {w['src_func']}")
-
-    # Message passing
-    print(f"\n--- Worker Message Passing ---")
-    for tid_str, info in s["message_passing"].items():
-        print(f"  tid={tid_str}: ser={info['serialize_ms']}ms({info['serialize_count']}x)  deser={info['deserialize_ms']}ms({info['deserialize_count']}x)")
-
-    print("\n" + "=" * 75)
-    print("END OF REPORT")
-    print("=" * 75)
+from trace_ultimate import analyze, print_report
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description='Analyze Chrome trace (legacy wrapper)')
+    p.add_argument('trace_path', nargs='?', help='Input trace path')
+    p.add_argument('--output-json', dest='output_json', help='Output JSON path override')
+    p.add_argument('--output-md', dest='output_md', help='Optional Markdown report path')
+    p.add_argument('--baseline-json', dest='baseline_json', help='Optional baseline JSON for comparison mode')
+    p.add_argument('--long-task-ms', dest='long_task_ms', type=int, default=50)
+    p.add_argument('--top', dest='top', type=int, default=15)
+    return p.parse_args()
 
 
 def main():
-    # Determine trace file path
-    if len(sys.argv) > 1:
-        trace_path = sys.argv[1]
-    else:
-        script_dir = Path(__file__).parent
-        trace_path = str(script_dir / "trace-keet-tracing.json")
+    args = parse_args()
 
-    if not os.path.exists(trace_path):
-        print(f"Error: Trace file not found: {trace_path}")
-        sys.exit(1)
+    trace_path = Path(args.trace_path) if args.trace_path else Path(__file__).parent / 'trace-keet-tracing.json'
+    if not trace_path.exists():
+        print(f'Error: Trace file not found: {trace_path}')
+        return 1
 
-    events = load_trace(trace_path)
-    pid_names, tid_names = build_maps(events)
-    ids = identify_renderer(pid_names, tid_names)
+    baseline_path = Path(args.baseline_json) if args.baseline_json else None
+    if baseline_path is not None and not baseline_path.exists():
+        print(f'Error: baseline JSON not found: {baseline_path}')
+        return 1
 
-    rpid = ids["renderer_pid"]
-    mtid = ids["main_tid"]
-    ctid = ids["compositor_tid"]
-    awtid = ids["audio_worklet_tid"]
-    wtids = ids["worker_tids"]
-    gpid = ids["gpu_pid"]
+    summary = analyze(
+        trace_path=trace_path,
+        baseline_json=baseline_path,
+        long_task_ms=args.long_task_ms,
+        top=args.top,
+    )
 
-    print(f"Renderer PID: {rpid}, Main TID: {mtid}, Workers: {wtids}, AudioWorklet: {awtid}, GPU: {gpid}")
-
-    # Trace duration
-    all_ts = [e.get("ts", 0) for e in events if e.get("ts", 0) > 0]
-    trace_dur_s = (max(all_ts) - min(all_ts)) / 1e6 if all_ts else 0
-
-    # Analyze each thread
-    print("Analyzing main thread...")
-    main_thread = analyze_thread_events(events, rpid, mtid, "Main Thread")
-    main_long = analyze_long_tasks(events, rpid, mtid)
-
-    print("Analyzing compositor...")
-    compositor = analyze_thread_events(events, rpid, ctid, "Compositor")
-
-    print("Analyzing workers...")
-    workers = []
-    worker_inference = {}
-    for wt in wtids:
-        label = f"Worker-{wt}"
-        w = analyze_thread_events(events, rpid, wt, label)
-        workers.append(w)
-        wi = analyze_worker_inference(events, rpid, wt)
-        worker_inference[str(wt)] = wi
-
-    print("Analyzing GC...")
-    all_tids = set(wtids) | {mtid, awtid} if awtid else set(wtids) | {mtid}
-    gc = analyze_gc(events, rpid, all_tids)
-
-    print("Analyzing WebGPU...")
-    webgpu = analyze_webgpu(events, gpid) if gpid else {"count": 0}
-
-    print("Analyzing AudioWorklet...")
-    audioworklet = analyze_audioworklet(events, rpid, awtid)
-
-    print("Analyzing frames...")
-    frames = analyze_frames(events, rpid, ctid) if ctid else {"draw_count": 0}
-
-    print("Analyzing WASM...")
-    wasm = analyze_wasm(events)
-
-    print("Analyzing message passing...")
-    msg = analyze_message_passing(events, rpid)
-
-    # Thread activity summary
-    thread_activity = [main_thread, compositor] + workers
-    if awtid:
-        aw_thread = analyze_thread_events(events, rpid, awtid, "AudioWorklet")
-        thread_activity.append(aw_thread)
-
-    # Build summary
-    summary = {
-        "trace_file": os.path.basename(trace_path),
-        "total_events": len(events),
-        "trace_duration_s": round(trace_dur_s, 1),
-        "thread_ids": ids,
-        "process_names": {str(k): v for k, v in pid_names.items()},
-        "thread_activity": [
-            {"label": t["label"], "total_dur_ms": t["total_dur_ms"]}
-            for t in sorted(thread_activity, key=lambda x: -x["total_dur_ms"])
-        ],
-        "main_thread": main_thread,
-        "main_thread_long_tasks": main_long,
-        "compositor": compositor,
-        "workers": workers,
-        "worker_inference": worker_inference,
-        "gc": gc,
-        "webgpu": webgpu,
-        "audioworklet": audioworklet,
-        "frames": frames,
-        "wasm": wasm,
-        "message_passing": msg,
-    }
-
-    # Print human-readable report
     print_report(summary)
 
-    # Write JSON summary
-    out_path = os.path.join(os.path.dirname(trace_path), "trace_analysis_summary.json")
-    with open(out_path, "w", encoding="utf-8") as f:
+    output_json = Path(args.output_json) if args.output_json else trace_path.with_name('trace_analysis_summary.json')
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    with output_json.open('w', encoding='utf-8') as f:
         json.dump(summary, f, indent=2)
-    print(f"\nJSON summary written to: {out_path}")
+    print(f'JSON summary written to: {output_json}')
+
+    if args.output_md:
+        from trace_ultimate import build_markdown
+
+        output_md = Path(args.output_md)
+        output_md.parent.mkdir(parents=True, exist_ok=True)
+        output_md.write_text(build_markdown(summary), encoding='utf-8')
+        print(f'Markdown report written to: {output_md}')
+
+    return 0
 
 
-if __name__ == "__main__":
-    main()
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/metrics/memory/analyze_heap_memory.py
+++ b/metrics/memory/analyze_heap_memory.py
@@ -1,0 +1,968 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import bisect
+import glob
+import json
+import re
+import shlex
+import sys
+from collections import Counter, deque
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+TIMESTAMP_RE = re.compile(r"Heap-(\d{8}T\d{6})")
+SUFFIXES = {".heapsnapshot", ".heaptimeline"}
+BUCKETS = [
+    ("detached_dom", "Detached DOM", []),
+    ("listeners", "Listener-Related", ["eventlistener", "listener"]),
+    ("collections", "Arrays/Maps/Queues", ["array", "map", "set", "queue", "list"]),
+    (
+        "buffers_typed",
+        "Buffers/Typed Arrays",
+        ["arraybuffer", "jsarraybufferdata", "float32array", "uint8array", "dataview"],
+    ),
+    ("worker_message", "Worker/Message", ["worker", "messageport", "messageevent"]),
+    (
+        "audio_render_debug",
+        "Audio/Render/Debug/Perf",
+        ["audio", "canvas", "render", "gpu", "performance", "debug"],
+    ),
+]
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def bfmt(v: int) -> str:
+    u = ["B", "KB", "MB", "GB"]
+    x = float(v)
+    for unit in u:
+        if abs(x) < 1024 or unit == u[-1]:
+            return f"{x:.2f} {unit}"
+        x /= 1024
+    return f"{v} B"
+
+
+def parse_ts(name: str) -> Optional[datetime]:
+    m = TIMESTAMP_RE.search(name)
+    if not m:
+        return None
+    try:
+        return datetime.strptime(m.group(1), "%Y%m%dT%H%M%S")
+    except ValueError:
+        return None
+
+
+@dataclass(frozen=True)
+class CaptureFile:
+    path: Path
+    kind: str
+    ts: Optional[datetime]
+    mtime: float
+
+    @property
+    def id(self) -> str:
+        return self.path.name
+
+    @property
+    def sort_time(self) -> datetime:
+        return self.ts if self.ts else datetime.fromtimestamp(self.mtime)
+
+
+def discover(inputs: Sequence[str]) -> List[CaptureFile]:
+    if not inputs:
+        raise ValueError("No --inputs provided.")
+    found: Dict[str, CaptureFile] = {}
+    for item in inputs:
+        matches = glob.glob(item, recursive=True)
+        cands = [Path(x) for x in matches] if matches else ([Path(item)] if Path(item).exists() else [])
+        for p in cands:
+            if p.is_dir():
+                for q in p.rglob("*"):
+                    if q.is_file() and q.suffix.lower() in SUFFIXES:
+                        k = "timeline" if q.suffix.lower() == ".heaptimeline" else "snapshot"
+                        found[str(q.resolve())] = CaptureFile(q.resolve(), k, parse_ts(q.name), q.stat().st_mtime)
+                continue
+            if not p.is_file() or p.suffix.lower() not in SUFFIXES:
+                continue
+            k = "timeline" if p.suffix.lower() == ".heaptimeline" else "snapshot"
+            found[str(p.resolve())] = CaptureFile(p.resolve(), k, parse_ts(p.name), p.stat().st_mtime)
+    out = sorted(found.values(), key=lambda c: (c.sort_time, c.path.name.lower()))
+    if not out:
+        raise ValueError("No .heapsnapshot/.heaptimeline files found.")
+    return out
+
+
+def validate(payload: Dict[str, Any], strict: bool) -> List[str]:
+    issues: List[str] = []
+    for k in ["snapshot", "nodes", "edges", "strings"]:
+        if k not in payload:
+            issues.append(f"missing key: {k}")
+    snap = payload.get("snapshot", {})
+    meta = snap.get("meta", {})
+    if not isinstance(meta, dict):
+        issues.append("missing snapshot.meta")
+    nf = meta.get("node_fields", [])
+    ef = meta.get("edge_fields", [])
+    if not isinstance(nf, list) or not isinstance(ef, list):
+        issues.append("invalid node_fields/edge_fields")
+    if isinstance(payload.get("nodes"), list) and isinstance(nf, list) and nf:
+        if len(payload["nodes"]) % len(nf) != 0:
+            issues.append("nodes shape mismatch")
+        c = len(payload["nodes"]) // len(nf)
+        if isinstance(snap.get("node_count"), int) and c != snap["node_count"]:
+            issues.append(f"node_count mismatch {snap['node_count']} vs {c}")
+    if isinstance(payload.get("edges"), list) and isinstance(ef, list) and ef:
+        if len(payload["edges"]) % len(ef) != 0:
+            issues.append("edges shape mismatch")
+        c = len(payload["edges"]) // len(ef)
+        if isinstance(snap.get("edge_count"), int) and c != snap["edge_count"]:
+            issues.append(f"edge_count mismatch {snap['edge_count']} vs {c}")
+    if strict and issues:
+        raise ValueError("; ".join(issues))
+    return issues
+
+
+class G:
+    def __init__(self, payload: Dict[str, Any]) -> None:
+        self.payload = payload
+        s, m = payload["snapshot"], payload["snapshot"]["meta"]
+        self.nodes, self.edges, self.strings = payload["nodes"], payload["edges"], payload["strings"]
+        self.nf, self.ef = m["node_fields"], m["edge_fields"]
+        self.nfc, self.efc = len(self.nf), len(self.ef)
+        self.n, self.e = s["node_count"], s["edge_count"]
+        self.extra_native = int(s.get("extra_native_bytes", 0))
+        self.nti, self.nni = self.nf.index("type"), self.nf.index("name")
+        self.nii, self.nsi = self.nf.index("id"), self.nf.index("self_size")
+        self.neci, self.ndi = self.nf.index("edge_count"), self.nf.index("detachedness")
+        self.eti, self.eni, self.eto = self.ef.index("type"), self.ef.index("name_or_index"), self.ef.index("to_node")
+        self.ntypes, self.etypes = m["node_types"][self.nti], m["edge_types"][self.eti]
+        self.typ = [""] * self.n
+        self.name = [""] * self.n
+        self.oid = [0] * self.n
+        self.selfs = [0] * self.n
+        self.ec = [0] * self.n
+        self.det = [0] * self.n
+        self.estart = [0] * self.n
+        cur = 0
+        for i in range(self.n):
+            b = i * self.nfc
+            t = self.nodes[b + self.nti]
+            nm = self.nodes[b + self.nni]
+            self.typ[i] = self.ntypes[t]
+            self.name[i] = self.strings[nm] if 0 <= nm < len(self.strings) else f"<s:{nm}>"
+            self.oid[i] = self.nodes[b + self.nii]
+            self.selfs[i] = self.nodes[b + self.nsi]
+            self.ec[i] = self.nodes[b + self.neci]
+            self.det[i] = self.nodes[b + self.ndi]
+            self.estart[i] = cur
+            cur += self.ec[i] * self.efc
+        self.pred = [[] for _ in range(self.n)]
+        self.strong_edges = 0
+        for v in range(self.n):
+            st, en = self.estart[v], self.estart[v] + self.ec[v] * self.efc
+            for p in range(st, en, self.efc):
+                et = self.etypes[self.edges[p + self.eti]]
+                if et == "weak":
+                    continue
+                w = self.edges[p + self.eto] // self.nfc
+                self.pred[w].append(v)
+                self.strong_edges += 1
+
+    def edge_name(self, et: str, noi: int) -> str:
+        return str(noi) if et == "element" else (self.strings[noi] if 0 <= noi < len(self.strings) else str(noi))
+
+    def out(self, i: int, strong: bool = True) -> Iterable[Tuple[str, str, int]]:
+        st, en = self.estart[i], self.estart[i] + self.ec[i] * self.efc
+        for p in range(st, en, self.efc):
+            et = self.etypes[self.edges[p + self.eti]]
+            if strong and et == "weak":
+                continue
+            to = self.edges[p + self.eto] // self.nfc
+            yield et, self.edge_name(et, self.edges[p + self.eni]), to
+
+
+def dominators(g: G, root: int = 0) -> Dict[str, Any]:
+    n = g.n
+    par, dfsn, seen, vert = [-1] * n, [0] * n, [False] * n, [-1]
+    st = [(root, 0, 0)]
+    k = 0
+    while st:
+        v, pos, mode = st.pop()
+        if mode == 0:
+            if seen[v]:
+                continue
+            seen[v] = True
+            k += 1
+            dfsn[v] = k
+            vert.append(v)
+            st.append((v, g.estart[v], 1))
+            continue
+        p, end = pos, g.estart[v] + g.ec[v] * g.efc
+        while p < end:
+            et = g.etypes[g.edges[p + g.eti]]
+            if et != "weak":
+                w = g.edges[p + g.eto] // g.nfc
+                if not seen[w]:
+                    par[w] = v
+                    st.append((v, p + g.efc, 1))
+                    st.append((w, 0, 0))
+                    break
+            p += g.efc
+    N, idom = k, [-1] * n
+    if N == 0:
+        return {"idom": idom, "ret": [0] * n, "dfsn": dfsn, "child": [[] for _ in range(n)], "reach": 0}
+    semi, anc, lab, buck = [0] * n, [-1] * n, list(range(n)), [[] for _ in range(n)]
+    for i in range(1, N + 1):
+        v = vert[i]
+        semi[v] = i
+        lab[v] = v
+
+    def comp(v: int) -> None:
+        if anc[v] != -1 and anc[anc[v]] != -1:
+            comp(anc[v])
+            if semi[lab[anc[v]]] < semi[lab[v]]:
+                lab[v] = lab[anc[v]]
+            anc[v] = anc[anc[v]]
+
+    def evalv(v: int) -> int:
+        if anc[v] == -1:
+            return lab[v]
+        comp(v)
+        return lab[anc[v]] if semi[lab[anc[v]]] < semi[lab[v]] else lab[v]
+
+    for i in range(N, 1, -1):
+        w, s = vert[i], semi[vert[i]]
+        for v in g.pred[w]:
+            if dfsn[v] == 0:
+                continue
+            u = evalv(v)
+            if semi[u] < s:
+                s = semi[u]
+        semi[w] = s
+        buck[vert[s]].append(w)
+        pw = par[w] if par[w] != -1 else root
+        anc[w] = pw
+        for v in buck[pw]:
+            u = evalv(v)
+            idom[v] = u if semi[u] < semi[v] else pw
+        buck[pw].clear()
+    for i in range(2, N + 1):
+        w = vert[i]
+        if idom[w] != vert[semi[w]]:
+            idom[w] = idom[idom[w]]
+    idom[root] = root
+    child = [[] for _ in range(n)]
+    for v in range(n):
+        if v == root or dfsn[v] == 0:
+            continue
+        p = idom[v]
+        if p != -1:
+            child[p].append(v)
+    ret, post = [0] * n, []
+    st2 = [(root, 0)]
+    while st2:
+        v, mode = st2.pop()
+        if mode == 0:
+            st2.append((v, 1))
+            for c in child[v]:
+                st2.append((c, 0))
+        else:
+            post.append(v)
+    for v in post:
+        ret[v] = g.selfs[v] + sum(ret[c] for c in child[v])
+    return {"idom": idom, "ret": ret, "dfsn": dfsn, "child": child, "reach": sum(1 for x in dfsn if x > 0)}
+
+
+def bfs_paths(g: G, root: int = 0) -> Tuple[List[int], List[str]]:
+    par, pedge, seen = [-1] * g.n, [""] * g.n, [False] * g.n
+    q: deque[int] = deque([root])
+    seen[root] = True
+    while q:
+        v = q.popleft()
+        for et, en, w in g.out(v, strong=True):
+            if seen[w]:
+                continue
+            seen[w] = True
+            par[w] = v
+            pedge[w] = f"{et}:{en}"
+            q.append(w)
+    return par, pedge
+
+
+def path_to(g: G, par: List[int], pedge: List[str], node: Optional[int]) -> Dict[str, Any]:
+    if node is None or node < 0 or node >= g.n or (node != 0 and par[node] == -1):
+        return {"reachable": False, "path_nodes": [], "path_text": "N/A"}
+    chain = [node]
+    x = node
+    while x != 0 and par[x] != -1 and len(chain) < 30:
+        x = par[x]
+        chain.append(x)
+    chain.reverse()
+    nodes, parts = [], []
+    for i, idx in enumerate(chain):
+        item = {
+            "node_index": idx,
+            "node_type": g.typ[idx],
+            "constructor": g.name[idx],
+            "self_size": g.selfs[idx],
+            "object_id": g.oid[idx],
+            "edge_from_parent": None if i == 0 else pedge[idx],
+        }
+        nodes.append(item)
+        if i == 0:
+            parts.append(f"#{idx} {g.typ[idx]} {g.name[idx]!r} self={g.selfs[idx]} id={g.oid[idx]}")
+        else:
+            parts.append(f"--{pedge[idx]}--> #{idx} {g.typ[idx]} {g.name[idx]!r} self={g.selfs[idx]} id={g.oid[idx]}")
+    return {"reachable": True, "path_nodes": nodes, "path_text": " ".join(parts)}
+
+
+@dataclass
+class A:
+    cap: CaptureFile
+    issues: List[str]
+    g: G
+    dom: Dict[str, Any]
+    par: List[int]
+    pedge: List[str]
+    c_count: Counter
+    c_self: Counter
+    t_count: Counter
+    t_self: Counter
+    buckets: Dict[str, Any]
+    top_ret: List[Dict[str, Any]]
+    detached: Dict[str, Any]
+    timeline: Dict[str, Any]
+
+
+def analyze_cap(cap: CaptureFile, payload: Dict[str, Any], strict: bool, top_n: int) -> A:
+    issues = validate(payload, strict)
+    g = G(payload)
+    dom = dominators(g, 0)
+    par, pedge = bfs_paths(g, 0)
+    c_count, c_self, t_count, t_self = Counter(), Counter(), Counter(), Counter()
+    for i in range(g.n):
+        c_count[g.name[i]] += 1
+        c_self[g.name[i]] += g.selfs[i]
+        t_count[g.typ[i]] += 1
+        t_self[g.typ[i]] += g.selfs[i]
+    ret = dom["ret"]
+    top_ret = []
+    for i in range(g.n):
+        if i == 0 or dom["dfsn"][i] == 0:
+            continue
+        if g.typ[i] == "synthetic" and g.name[i].startswith("("):
+            continue
+        top_ret.append({"node_index": i, "constructor": g.name[i], "node_type": g.typ[i], "self_size": g.selfs[i], "retained_size": ret[i], "detachedness": g.det[i], "object_id": g.oid[i]})
+    top_ret.sort(key=lambda x: (x["retained_size"], x["self_size"]), reverse=True)
+    det_nodes = [i for i, d in enumerate(g.det) if d]
+    det_set = set(det_nodes)
+    det_roots = [i for i in det_nodes if dom["idom"][i] == -1 or dom["idom"][i] == i or dom["idom"][i] not in det_set]
+    detached = {
+        "detached_node_count": len(det_nodes),
+        "detached_self_size": int(sum(g.selfs[i] for i in det_nodes)),
+        "detached_retained_nonunique": int(sum(ret[i] for i in det_nodes)),
+        "detached_retained_unique_estimate": int(sum(ret[i] for i in det_roots)),
+        "detached_root_like_nodes": len(det_roots),
+        "top_detached_nodes": sorted(({"node_index": i, "constructor": g.name[i], "node_type": g.typ[i], "self_size": g.selfs[i], "retained_size": ret[i], "detachedness": g.det[i]} for i in det_nodes), key=lambda x: (x["retained_size"], x["self_size"]), reverse=True)[:top_n],
+    }
+    names_l = [x.lower() for x in g.name]
+    buckets: Dict[str, Any] = {}
+    for bid, label, pats in BUCKETS:
+        idxs = det_nodes if bid == "detached_dom" else [i for i, ln in enumerate(names_l) if any(p in ln for p in pats)]
+        sidx = set(idxs)
+        roots = [i for i in idxs if dom["idom"][i] == -1 or dom["idom"][i] == i or dom["idom"][i] not in sidx]
+        buckets[bid] = {
+            "label": label,
+            "count": len(idxs),
+            "self_size_sum": int(sum(g.selfs[i] for i in idxs)),
+            "retained_sum_nonunique": int(sum(ret[i] for i in idxs)),
+            "retained_unique_estimate": int(sum(ret[i] for i in roots)),
+            "top_nodes": sorted(({"node_index": i, "constructor": g.name[i], "node_type": g.typ[i], "self_size": g.selfs[i], "retained_size": ret[i], "detachedness": g.det[i]} for i in idxs), key=lambda x: (x["retained_size"], x["self_size"]), reverse=True)[:top_n],
+        }
+    timeline: Dict[str, Any] = {"sample_fields": [], "sample_count": 0, "top_id_growth_bursts": [], "survivor_pressure_checkpoints": []}
+    if cap.kind == "timeline" or payload.get("samples"):
+        sf = payload["snapshot"]["meta"].get("sample_fields", [])
+        smp = payload.get("samples", [])
+        timeline["sample_fields"] = sf
+        if sf and smp and len(smp) % len(sf) == 0:
+            w, rows = len(sf), len(smp) // len(sf)
+            timeline["sample_count"] = rows
+            fmap = {n: i for i, n in enumerate(sf)}
+            ti, ii = fmap.get("timestamp_us", 0), fmap.get("last_assigned_id", 1 if w > 1 else None)
+            if ii is not None:
+                tv, iv = [int(smp[r * w + ti]) for r in range(rows)], [int(smp[r * w + ii]) for r in range(rows)]
+                tmin, tmax = min(tv), max(tv)
+                timeline["timestamp_range_us"] = [tmin, tmax]
+                timeline["duration_seconds"] = round((tmax - tmin) / 1_000_000.0, 6)
+                timeline["id_range"] = [min(iv), max(iv)]
+                bursts = []
+                for i in range(1, len(tv)):
+                    dt, did = tv[i] - tv[i - 1], iv[i] - iv[i - 1]
+                    if dt > 0:
+                        bursts.append({"sample_index": i, "delta_id": did, "delta_time_us": dt, "id_per_us": did / dt})
+                bursts.sort(key=lambda x: x["id_per_us"], reverse=True)
+                timeline["top_id_growth_bursts"] = bursts[:top_n]
+                tot = max(1, sum(g.selfs))
+                for cp in [0.0, 0.25, 0.5, 0.75, 0.9, 0.99, 1.0]:
+                    tt = tmin + int((tmax - tmin) * cp)
+                    pos = min(len(tv) - 1, bisect.bisect_left(tv, tt))
+                    thr = iv[pos]
+                    ss = sum(s for oid, s in zip(g.oid, g.selfs) if oid <= thr)
+                    timeline["survivor_pressure_checkpoints"].append({"checkpoint": cp, "id_threshold": thr, "survivor_self_size": ss, "survivor_ratio": ss / tot})
+    return A(cap, issues, g, dom, par, pedge, c_count, c_self, t_count, t_self, buckets, top_ret, detached, timeline)
+
+
+def top_counter(c: Counter, n: int) -> List[Dict[str, Any]]:
+    return [{"name": k, "value": v} for k, v in c.most_common(n)]
+
+
+def summary(a: A, n: int) -> Dict[str, Any]:
+    return {
+        "capture_id": a.cap.id,
+        "path": str(a.cap.path),
+        "kind": a.cap.kind,
+        "timestamp": a.cap.sort_time.isoformat(),
+        "validation_issues": a.issues,
+        "node_count": a.g.n,
+        "edge_count": a.g.e,
+        "strong_edge_count": a.g.strong_edges,
+        "reachable_nodes": a.dom["reach"],
+        "total_heap_self_size": int(sum(a.g.selfs)),
+        "extra_native_bytes": a.g.extra_native,
+        "constructor_count_top": top_counter(a.c_count, n),
+        "constructor_self_top": top_counter(a.c_self, n),
+        "type_count": top_counter(a.t_count, n),
+        "type_self": top_counter(a.t_self, n),
+        "detached_summary": a.detached,
+        "top_retained_owners": a.top_ret[:n],
+        "pattern_buckets": a.buckets,
+        "timeline": a.timeline,
+    }
+
+
+def compare(old: A, new: A, n: int) -> Dict[str, Any]:
+    ctors = set(old.c_self) | set(new.c_self)
+    cd = []
+    for c in ctors:
+        ds = int(new.c_self[c] - old.c_self[c])
+        dc = int(new.c_count[c] - old.c_count[c])
+        if ds == 0 and dc == 0:
+            continue
+        cd.append(
+            {
+                "constructor": c,
+                "delta_self_size": ds,
+                "delta_count": dc,
+                "older_self_size": int(old.c_self[c]),
+                "newer_self_size": int(new.c_self[c]),
+                "older_count": int(old.c_count[c]),
+                "newer_count": int(new.c_count[c]),
+            }
+        )
+    cd.sort(key=lambda x: x["delta_self_size"], reverse=True)
+    types = set(old.t_self) | set(new.t_self)
+    td = []
+    for t in types:
+        ds = int(new.t_self[t] - old.t_self[t])
+        dc = int(new.t_count[t] - old.t_count[t])
+        if ds == 0 and dc == 0:
+            continue
+        td.append(
+            {
+                "node_type": t,
+                "delta_self_size": ds,
+                "delta_count": dc,
+                "older_self_size": int(old.t_self[t]),
+                "newer_self_size": int(new.t_self[t]),
+                "older_count": int(old.t_count[t]),
+                "newer_count": int(new.t_count[t]),
+            }
+        )
+    td.sort(key=lambda x: x["delta_self_size"], reverse=True)
+    bd: Dict[str, Any] = {}
+    for bid, label, _ in BUCKETS:
+        ob, nb = old.buckets.get(bid, {}), new.buckets.get(bid, {})
+        bd[bid] = {
+            "label": label,
+            "older_count": int(ob.get("count", 0)),
+            "newer_count": int(nb.get("count", 0)),
+            "delta_count": int(nb.get("count", 0) - ob.get("count", 0)),
+            "older_self_size": int(ob.get("self_size_sum", 0)),
+            "newer_self_size": int(nb.get("self_size_sum", 0)),
+            "delta_self_size": int(nb.get("self_size_sum", 0) - ob.get("self_size_sum", 0)),
+            "older_retained_unique_estimate": int(ob.get("retained_unique_estimate", 0)),
+            "newer_retained_unique_estimate": int(nb.get("retained_unique_estimate", 0)),
+            "delta_retained_unique_estimate": int(nb.get("retained_unique_estimate", 0) - ob.get("retained_unique_estimate", 0)),
+        }
+    delta_total_heap = int(sum(new.g.selfs) - sum(old.g.selfs))
+    ctor_delta_self_total = int(sum(x["delta_self_size"] for x in cd))
+    ctor_delta_count_total = int(sum(x["delta_count"] for x in cd))
+    type_delta_self_total = int(sum(x["delta_self_size"] for x in td))
+    type_delta_count_total = int(sum(x["delta_count"] for x in td))
+    return {
+        "older_capture_id": old.cap.id,
+        "newer_capture_id": new.cap.id,
+        "older_timestamp": old.cap.sort_time.isoformat(),
+        "newer_timestamp": new.cap.sort_time.isoformat(),
+        "delta_total_heap_self_size": delta_total_heap,
+        "delta_extra_native_bytes": int(new.g.extra_native - old.g.extra_native),
+        "delta_node_count": int(new.g.n - old.g.n),
+        "delta_edge_count": int(new.g.e - old.g.e),
+        "constructor_delta_self_total": ctor_delta_self_total,
+        "constructor_delta_count_total": ctor_delta_count_total,
+        "constructor_delta_self_matches_total_heap": bool(ctor_delta_self_total == delta_total_heap),
+        "type_delta_self_total": type_delta_self_total,
+        "type_delta_count_total": type_delta_count_total,
+        "type_delta_self_matches_total_heap": bool(type_delta_self_total == delta_total_heap),
+        "constructor_deltas_top_growth": [x for x in cd if x["delta_self_size"] > 0][:n],
+        "constructor_deltas_top_shrink": [x for x in sorted(cd, key=lambda y: y["delta_self_size"]) if x["delta_self_size"] < 0][:n],
+        "type_deltas_top_growth": [x for x in td if x["delta_self_size"] > 0][:n],
+        "type_deltas_top_shrink": [x for x in sorted(td, key=lambda y: y["delta_self_size"]) if x["delta_self_size"] < 0][:n],
+        "bucket_deltas": bd,
+    }
+
+
+def ctor_delta(cmpd: Dict[str, Any], ctor: str) -> Optional[Dict[str, Any]]:
+    for x in cmpd["constructor_deltas_top_growth"] + cmpd["constructor_deltas_top_shrink"]:
+        if x["constructor"] == ctor:
+            return x
+    return None
+
+
+def best_node(a: A, ctor: str, min_oid: Optional[int] = None) -> Optional[int]:
+    cands = []
+    for i, n in enumerate(a.g.name):
+        if n != ctor:
+            continue
+        if min_oid is not None and a.g.oid[i] <= min_oid:
+            continue
+        cands.append(i)
+    return max(cands, key=lambda i: a.g.selfs[i]) if cands else None
+
+
+def path_owner_hint(text: str) -> str:
+    t = text.lower()
+    if "pendingpromises" in t:
+        return "pendingPromises map retains unresolved async payload state."
+    if "ringbuffer" in t:
+        return "Audio ring buffer retains typed-array backing store."
+    if "visualizationbuffer" in t:
+        return "Visualization buffer retained by long-lived audio object."
+    if "performanceobserver" in t or "performanceeventtiming" in t:
+        return "PerformanceObserver/event timing chain."
+    return "Owner chain present but only partially attributable."
+
+
+def pending_info(a: A) -> Dict[str, Any]:
+    g = a.g
+    maps, tables, entries = 0, 0, 0
+    max_buf, max_node = 0, None
+
+    def feat_buf(entry: int) -> Tuple[int, Optional[int]]:
+        best, node = 0, None
+        for et1, en1, n1 in g.out(entry):
+            if et1 != "property" or en1 != "features":
+                continue
+            for et2, en2, n2 in g.out(n1):
+                if et2 != "internal" or en2 != "buffer":
+                    continue
+                for et3, en3, n3 in g.out(n2):
+                    if et3 == "internal" and en3 == "backing_store":
+                        if g.selfs[n3] > best:
+                            best, node = g.selfs[n3], n3
+        return best, node
+
+    for owner in range(g.n):
+        for et, en, m in g.out(owner):
+            if et == "property" and en == "pendingPromises":
+                maps += 1
+                table = None
+                for et2, en2, n2 in g.out(m):
+                    if et2 == "internal" and en2 == "table":
+                        table = n2
+                        break
+                if table is None:
+                    continue
+                tables += 1
+                for et3, en3, ent in g.out(table):
+                    if et3 != "internal" or en3 == "map":
+                        continue
+                    if g.typ[ent] == "hidden" and g.name[ent].startswith("system / Map"):
+                        continue
+                    entries += 1
+                    s, n = feat_buf(ent)
+                    if s > max_buf:
+                        max_buf, max_node = s, n
+    return {"map_count": maps, "table_count": tables, "entry_count": entries, "max_feature_buffer_size": int(max_buf), "max_feature_buffer_node": max_node}
+
+
+def monotonic(comparisons: List[Dict[str, Any]], ctor: str) -> bool:
+    if len(comparisons) < 2:
+        return False
+    vals = []
+    for c in comparisons:
+        d = ctor_delta(c, ctor)
+        vals.append(int(d["delta_self_size"]) if d else 0)
+    return all(v > 0 for v in vals)
+
+
+def conf(clear_path: bool, mono: bool, cap_count: int, browser_amb: bool = False) -> Tuple[str, str]:
+    if browser_amb:
+        return "low", "Signal likely browser/runtime-internal."
+    if cap_count >= 3 and mono and clear_path:
+        return "high", "Monotonic multi-interval growth with clear owner path."
+    if clear_path:
+        return "medium", "Growth in this pair plus plausible owner path; needs repeat confirmation."
+    return "low", "Growth signal present but owner ambiguity remains."
+
+
+def findings(analyses: List[A], comparisons: List[Dict[str, Any]], top_n: int) -> List[Dict[str, Any]]:
+    if len(analyses) < 2:
+        return []
+    old, new = analyses[0], analyses[-1]
+    anchor = compare(old, new, top_n)
+    old_max = max(old.g.oid) if old.g.oid else None
+    out: List[Dict[str, Any]] = []
+
+    d = ctor_delta(anchor, "system / JSArrayBufferData")
+    if d and d["delta_self_size"] > 0:
+        node = best_node(new, "system / JSArrayBufferData", old_max) or best_node(new, "system / JSArrayBufferData")
+        p = path_to(new.g, new.par, new.pedge, node)
+        clear = any(t in p["path_text"].lower() for t in ["ringbuffer", "pendingpromises", "visualizationbuffer", "features"])
+        c, cr = conf(clear, monotonic(comparisons, "system / JSArrayBufferData"), len(analyses))
+        out.append(
+            {
+                "symptom": "Typed-array backing store grew between captures.",
+                "suspected_owner": path_owner_hint(p["path_text"]),
+                "evidence": {
+                    "constructor": "system / JSArrayBufferData",
+                    "delta_self_size": d["delta_self_size"],
+                    "older_self_size": d["older_self_size"],
+                    "newer_self_size": d["newer_self_size"],
+                    "older_count": d["older_count"],
+                    "newer_count": d["newer_count"],
+                    "capture_window": {"older": old.cap.id, "newer": new.cap.id},
+                },
+                "retention_path": p,
+                "impact": "Backing-store growth raises long-session memory pressure and GC cost.",
+                "impact_bytes": int(d["delta_self_size"]),
+                "why_degrades_performance": "Long-lived native backing stores shrink free headroom and increase memory-management overhead.",
+                "confidence": c,
+                "confidence_reason": cr,
+                "false_positive_checks": [
+                    "If fixed-size warmup/pool behavior, growth should plateau after forced-GC idle.",
+                    "If intended buffers, constructor count should stabilize during steady state.",
+                ],
+                "next_validation": [
+                    "Run forced-GC idle A/B snapshots and check JSArrayBufferData plateau.",
+                    "Run 10-minute active session then stop/drain and verify post-drain baseline.",
+                ],
+            }
+        )
+
+    po, pn = pending_info(old), pending_info(new)
+    if pn["entry_count"] > po["entry_count"] or pn["max_feature_buffer_size"] > po["max_feature_buffer_size"]:
+        p = path_to(new.g, new.par, new.pedge, pn["max_feature_buffer_node"])
+        c, cr = conf("pendingpromises" in p["path_text"].lower(), False, len(analyses))
+        out.append(
+            {
+                "symptom": "pendingPromises map retained additional unresolved worker-result state.",
+                "suspected_owner": "pendingPromises map on worker client object.",
+                "evidence": {
+                    "older_pending": po,
+                    "newer_pending": pn,
+                    "entry_delta": int(pn["entry_count"] - po["entry_count"]),
+                    "feature_buffer_delta": int(pn["max_feature_buffer_size"] - po["max_feature_buffer_size"]),
+                    "capture_window": {"older": old.cap.id, "newer": new.cap.id},
+                },
+                "retention_path": p,
+                "impact": "Pending async entries can pin buffers/promises and raise baseline memory.",
+                "impact_bytes": int(max(0, pn["max_feature_buffer_size"] - po["max_feature_buffer_size"])),
+                "why_degrades_performance": "Pinned async state delays reclamation of large payload objects.",
+                "confidence": c,
+                "confidence_reason": cr,
+                "false_positive_checks": [
+                    "Transient in-flight work may appear mid-capture.",
+                    "Confirm behavior after explicit stop and queue drain."
+                ],
+                "next_validation": [
+                    "Capture active stream then stop/drain; verify pending entry count returns to zero.",
+                    "Capture post-drain forced-GC snapshot and compare retained feature buffers.",
+                ],
+            }
+        )
+
+    dd = int(new.detached["detached_node_count"] - old.detached["detached_node_count"])
+    dr = int(new.detached["detached_retained_unique_estimate"] - old.detached["detached_retained_unique_estimate"])
+    if dd > 0 or dr > 0:
+        top = new.detached["top_detached_nodes"][0]["node_index"] if new.detached["top_detached_nodes"] else None
+        p = path_to(new.g, new.par, new.pedge, top)
+        out.append(
+            {
+                "symptom": "Detached DOM node count increased between captures.",
+                "suspected_owner": "UI subtree mount/unmount lifecycle.",
+                "evidence": {
+                    "older_detached_count": old.detached["detached_node_count"],
+                    "newer_detached_count": new.detached["detached_node_count"],
+                    "delta_detached_count": dd,
+                    "older_detached_retained_unique_estimate": old.detached["detached_retained_unique_estimate"],
+                    "newer_detached_retained_unique_estimate": new.detached["detached_retained_unique_estimate"],
+                    "delta_detached_retained_unique_estimate": dr,
+                },
+                "retention_path": p,
+                "impact": "Detached trees may accumulate UI memory overhead over long sessions.",
+                "impact_bytes": int(max(0, dr)),
+                "why_degrades_performance": "Detached nodes keep style/layout related objects alive.",
+                "confidence": "low",
+                "confidence_reason": "Single-pair signal with relatively small retained impact.",
+                "false_positive_checks": [
+                    "Minor detached-node fluctuations can be normal reconciliation noise.",
+                    "Require repeated post-GC growth for leak confirmation."
+                ],
+                "next_validation": [
+                    "Run repeated UI toggle cycles and compare post-GC detached retained deltas.",
+                    "Capture idle-after-interaction to confirm reclamation."
+                ],
+            }
+        )
+
+    pd = ctor_delta(anchor, "PerformanceEventTiming")
+    if pd and pd["delta_self_size"] > 0:
+        node = best_node(new, "PerformanceEventTiming")
+        p = path_to(new.g, new.par, new.pedge, node)
+        c, cr = conf(False, False, len(analyses), browser_amb=True)
+        out.append(
+            {
+                "symptom": "PerformanceEventTiming objects increased across captures.",
+                "suspected_owner": path_owner_hint(p["path_text"]),
+                "evidence": {"constructor": "PerformanceEventTiming", "delta_self_size": pd["delta_self_size"], "older_count": pd["older_count"], "newer_count": pd["newer_count"]},
+                "retention_path": p,
+                "impact": "May raise background memory overhead and diagnostics noise.",
+                "impact_bytes": int(pd["delta_self_size"]),
+                "why_degrades_performance": "Large timing-entry arrays increase retained object graph scanning.",
+                "confidence": c,
+                "confidence_reason": cr,
+                "false_positive_checks": [
+                    "Browser timing buffers are expected unless app collections retain entries indefinitely.",
+                    "Need repeated post-GC idling to distinguish bounded vs unbounded accumulation."
+                ],
+                "next_validation": [
+                    "Capture post-GC idle snapshots without interaction and verify plateau.",
+                    "Inspect observer draining behavior in targeted run."
+                ],
+            }
+        )
+
+    tls = [a for a in analyses if a.timeline.get("sample_count", 0) > 0]
+    if tls:
+        t = tls[-1].timeline
+        bursts = t.get("top_id_growth_bursts", [])
+        cps = t.get("survivor_pressure_checkpoints", [])
+        mr = float(bursts[0]["id_per_us"]) if bursts else 0.0
+        r75 = 0.0
+        for cp in cps:
+            if abs(cp.get("checkpoint", -1) - 0.75) < 1e-9:
+                r75 = float(cp.get("survivor_ratio", 0.0))
+                break
+        if mr > 0:
+            c = "medium" if r75 >= 0.30 else "low"
+            out.append(
+                {
+                    "symptom": "Timeline shows bursty allocation and non-trivial survivor baseline.",
+                    "suspected_owner": "Mixed runtime/app allocation churn during active processing.",
+                    "evidence": {"capture_id": tls[-1].cap.id, "sample_count": t.get("sample_count", 0), "duration_seconds": t.get("duration_seconds", 0.0), "max_id_growth_rate_per_us": mr, "survivor_ratio_at_75pct": r75},
+                    "retention_path": {"reachable": False, "path_nodes": [], "path_text": "N/A (aggregate timeline signal)"},
+                    "impact": "Allocation churn with survivors can increase GC frequency and pause overhead.",
+                    "impact_bytes": int(cps[-1]["survivor_self_size"] if cps else 0),
+                    "why_degrades_performance": "Bursty allocation increases mutator interruptions; survivors raise old-generation pressure.",
+                    "confidence": c,
+                    "confidence_reason": "Aggregate signal needs repeated runs for leak-level certainty.",
+                    "false_positive_checks": [
+                        "Single run may include warmup transients.",
+                        "Need active-vs-idle repetition to prove persistent churn."
+                    ],
+                    "next_validation": [
+                        "Record timeline during steady-state idle after warmup.",
+                        "Repeat 10-minute active run and compare burst/survivor profile."
+                    ],
+                }
+            )
+
+    w = {"high": 3, "medium": 2, "low": 1}
+    for f in out:
+        c = w.get(f["confidence"], 1)
+        f["_score"] = int(f.get("impact_bytes", 0)) * (1 + (0.2 * c)) + (1000 * c)
+    out.sort(key=lambda f: f["_score"], reverse=True)
+    for i, f in enumerate(out, 1):
+        f["rank"] = i
+        f["finding_id"] = f"F{i:02d}"
+        f.pop("_score", None)
+    return out
+
+
+def report_obj(analyses: List[A], comparisons: List[Dict[str, Any]], findings_list: List[Dict[str, Any]], top_n: int, cmd: str) -> Dict[str, Any]:
+    caps = [summary(a, top_n) for a in analyses]
+    anchor = comparisons[-1] if comparisons else None
+    return {
+        "generated_at": now_iso(),
+        "analyzer": "metrics/memory/analyze_heap_memory.py",
+        "inputs": [str(a.cap.path) for a in analyses],
+        "captures": caps,
+        "comparisons": comparisons,
+        "findings": findings_list,
+        "appendix": {
+            "top_growing_constructors": (anchor["constructor_deltas_top_growth"][:top_n] if anchor else []),
+            "top_growing_types": (anchor["type_deltas_top_growth"][:top_n] if anchor else []),
+            "largest_retained_groups": (analyses[-1].top_ret[:top_n] if analyses else []),
+            "commands_used": [cmd],
+        },
+    }
+
+
+def report_md(rep: Dict[str, Any], analyses: List[A], cmd: str) -> str:
+    ls: List[str] = []
+    ls += [
+        "# Keet Memory Profiling Report - Pass 1 (Heap-Only)",
+        "",
+        f"- Generated at: `{rep['generated_at']}`",
+        f"- Analyzer: `{rep['analyzer']}`",
+        f"- Command: `{cmd}`",
+        "",
+        "## 1. Executive summary",
+        "",
+    ]
+    if rep["findings"]:
+        for f in rep["findings"]:
+            ls.append(f"{f['rank']}. `{f['finding_id']}` ({f['confidence']}) - {f['symptom']} Impact signal: `{bfmt(int(f.get('impact_bytes', 0)))}`")
+    else:
+        ls.append("1. No ranked risks generated from available captures.")
+    ls += [
+        "",
+        "Data sufficiency note: this pass has limited temporal depth (two captures), so findings are provisional until repeated post-GC runs confirm monotonic trends.",
+        "",
+        "## 2. Method",
+        "",
+        "### Files analyzed",
+        "",
+    ]
+    for c in rep["captures"]:
+        ls.append(f"- `{c['capture_id']}` ({c['kind']}), nodes={c['node_count']}, edges={c['edge_count']}, total_self={bfmt(int(c['total_heap_self_size']))}")
+    ls += ["", "### Comparison strategy", ""]
+    if rep["comparisons"]:
+        for c in rep["comparisons"]:
+            ls.append(f"- `{c['older_capture_id']}` -> `{c['newer_capture_id']}` (delta_total_heap_self_size={bfmt(int(c['delta_total_heap_self_size']))})")
+    else:
+        ls.append("- Single capture only; no deltas.")
+    ls += ["", "### Custom tooling/scripts", "", "- `metrics/memory/analyze_heap_memory.py`", "- CLI supports `--inputs`, `--report-md`, `--report-json`, `--top-n`, `--pairwise`, `--strict-validate`", "", "## 3. Findings (ranked)", ""]
+    if rep["findings"]:
+        for f in rep["findings"]:
+            ls += [
+                f"### {f['rank']}. {f['finding_id']} - {f['symptom']}",
+                "",
+                f"- Symptom: {f['symptom']}",
+                f"- Evidence: `{json.dumps(f['evidence'], ensure_ascii=True)}`",
+                f"- Suspected retention path / owner: {f['suspected_owner']}",
+                f"- Retention path: `{f['retention_path']['path_text']}`",
+                f"- Why it degrades over time: {f['why_degrades_performance']}",
+                f"- Confidence: `{f['confidence']}` ({f['confidence_reason']})",
+                f"- False-positive checks: {' | '.join(f['false_positive_checks'])}",
+                f"- Next validation run(s): {' | '.join(f['next_validation'])}",
+                "",
+            ]
+    else:
+        ls += ["- No findings generated.", ""]
+    ls += [
+        "## 4. False-positive checks",
+        "",
+        "- Treat startup/model/audio warmup growth as non-leak unless growth persists after forced-GC idle.",
+        "- Treat fixed-size pools/ring buffers as expected when cardinality and bytes plateau.",
+        "- Treat browser timing-entry accumulation as provisional unless app-owned containers retain unboundedly.",
+        "- Promote to likely leak only with repeated post-GC growth trends.",
+        "",
+        "## 5. Recommended next validation runs",
+        "",
+        "1. Idle stabilization: snapshot A after warmup, force GC, 60s idle, snapshot B.",
+        "2. Active transcription loop: 10-minute active run with interactions, timeline capture, force GC, snapshot C.",
+        "3. Pending-work verification: capture during active stream, stop/drain, snapshot D post-drain.",
+        "4. Detached DOM regression: repeat panel/device toggle loop and compare post-GC detached deltas.",
+        "",
+        "## 6. Appendix",
+        "",
+        "### Top growing constructors/types",
+        "",
+    ]
+    tc = rep["appendix"]["top_growing_constructors"]
+    if tc:
+        ls += ["| Constructor | Delta Self | Delta Count |", "|---|---:|---:|"]
+        for r in tc:
+            ls.append(f"| `{r['constructor']}` | {r['delta_self_size']} | {r['delta_count']} |")
+    else:
+        ls.append("- No constructor growth rows.")
+    ls += ["", "### Largest retained objects/groups", "", "| Node | Constructor | Type | Self | Retained |", "|---:|---|---|---:|---:|"]
+    for r in analyses[-1].top_ret[:20]:
+        ls.append(f"| {r['node_index']} | `{r['constructor']}` | `{r['node_type']}` | {r['self_size']} | {r['retained_size']} |")
+    ls += ["", "### CLI commands used", ""]
+    for c in rep["appendix"]["commands_used"]:
+        ls.append(f"- `{c}`")
+    ls.append("")
+    return "\n".join(ls)
+
+
+def args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Analyze Chrome heap captures for memory growth risks.")
+    p.add_argument("--inputs", nargs="+", required=True)
+    p.add_argument("--report-md", required=True)
+    p.add_argument("--report-json", required=True)
+    p.add_argument("--top-n", type=int, default=25)
+    p.add_argument("--pairwise", action="store_true")
+    p.add_argument("--strict-validate", action="store_true")
+    return p.parse_args(argv)
+
+
+def wjson(path: Path, obj: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, indent=2), encoding="utf-8")
+
+
+def wtxt(path: Path, s: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(s, encoding="utf-8")
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    a = args(argv)
+    cmd = "python " + " ".join(shlex.quote(x) for x in sys.argv)
+    caps = discover(a.inputs)
+    print(f"[analyze] captures={len(caps)}")
+    analyses: List[A] = []
+    for c in caps:
+        print(f"[analyze] load {c.path.name}")
+        payload = json.loads(c.path.read_text(encoding="utf-8"))
+        analyses.append(analyze_cap(c, payload, a.strict_validate, a.top_n))
+    comps: List[Dict[str, Any]] = []
+    if len(analyses) >= 2:
+        if a.pairwise:
+            for i in range(1, len(analyses)):
+                comps.append(compare(analyses[i - 1], analyses[i], a.top_n))
+        anchor = compare(analyses[0], analyses[-1], a.top_n)
+        if not comps or comps[-1]["older_capture_id"] != anchor["older_capture_id"] or comps[-1]["newer_capture_id"] != anchor["newer_capture_id"]:
+            comps.append(anchor)
+    f = findings(analyses, comps, a.top_n)
+    rep = report_obj(analyses, comps, f, a.top_n, cmd)
+    md = report_md(rep, analyses, cmd)
+    wjson(Path(a.report_json), rep)
+    wtxt(Path(a.report_md), md)
+    print(f"[analyze] wrote {a.report_json}")
+    print(f"[analyze] wrote {a.report_md}")
+    print(f"[analyze] findings={len(f)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/metrics/trace_ultimate.py
+++ b/metrics/trace_ultimate.py
@@ -1,0 +1,702 @@
+#!/usr/bin/env python3
+"""
+Ultimate Chrome trace analyzer for Keet.
+
+Usage examples:
+  python metrics/trace_ultimate.py traces/Trace-20260217T235732.json \
+    --output-json traces/baseline.ultimate.json \
+    --output-md traces/baseline.ultimate.md
+
+  python metrics/trace_ultimate.py traces/Trace-after.json \
+    --baseline-json traces/baseline.ultimate.json \
+    --output-json traces/after.ultimate.json \
+    --output-md traces/after.ultimate.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from collections import defaultdict
+from pathlib import Path
+from statistics import mean
+
+
+def to_float(value, default=0.0):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def percentile(sorted_vals, q):
+    if not sorted_vals:
+        return 0.0
+    idx = int(max(0.0, min(1.0, q)) * (len(sorted_vals) - 1))
+    return sorted_vals[idx]
+
+
+def load_trace(trace_path: Path):
+    with trace_path.open('r', encoding='utf-8') as f:
+        raw = json.load(f)
+    if isinstance(raw, dict):
+        events = raw.get('traceEvents', [])
+    elif isinstance(raw, list):
+        events = raw
+    else:
+        events = []
+    if not isinstance(events, list):
+        raise ValueError('Invalid trace format: traceEvents is not a list')
+    events = [e for e in events if isinstance(e, dict)]
+    return events
+
+
+def trace_duration_s(events, renderer_pid=None):
+    scoped = events
+    if renderer_pid is not None:
+        scoped = [e for e in events if e.get('pid') == renderer_pid and e.get('ph') == 'X']
+        if not scoped:
+            scoped = [e for e in events if e.get('pid') == renderer_pid]
+
+    points = []
+    for e in scoped:
+        ts = to_float(e.get('ts'), None)
+        if ts is None:
+            continue
+        dur = to_float(e.get('dur'), 0.0)
+        points.append(ts)
+        points.append(ts + dur)
+
+    if not points:
+        return 0.0
+    return round((max(points) - min(points)) / 1_000_000.0, 2)
+
+
+def build_meta(events):
+    pid_names = {}
+    tid_names = {}
+    worker_urls = {}
+
+    for e in events:
+        ph = e.get('ph')
+        name = e.get('name')
+        pid = e.get('pid')
+        tid = e.get('tid')
+        args = e.get('args') or {}
+
+        if ph == 'M' and name == 'process_name' and pid is not None:
+            pname = (args.get('name') or '').strip()
+            if pname:
+                pid_names[int(pid)] = pname
+        elif ph == 'M' and name == 'thread_name' and pid is not None and tid is not None:
+            tname = (args.get('name') or '').strip()
+            if tname:
+                tid_names[(int(pid), int(tid))] = tname
+
+        if name == 'TracingSessionIdForWorker':
+            data = args.get('data') if isinstance(args.get('data'), dict) else args
+            if isinstance(data, dict):
+                wt = data.get('workerThreadId')
+                if wt is None:
+                    wt = tid
+                url = data.get('url') or data.get('scriptURL') or data.get('workerUrl')
+                if wt is not None and url:
+                    worker_urls[int(wt)] = str(url)
+
+    renderer_pids = [pid for pid, n in pid_names.items() if 'renderer' in n.lower()]
+    gpu_pid = next((pid for pid, n in pid_names.items() if 'gpu process' in n.lower()), None)
+
+    renderer_pid = None
+    if renderer_pids:
+        has_main = [
+            pid for pid in renderer_pids
+            if any(p == pid and name == 'CrRendererMain' for (p, _), name in tid_names.items())
+        ]
+        if has_main:
+            renderer_pid = has_main[0]
+        else:
+            counts = defaultdict(int)
+            for (pid, _), _ in tid_names.items():
+                if pid in renderer_pids:
+                    counts[pid] += 1
+            renderer_pid = max(counts, key=counts.get) if counts else renderer_pids[0]
+
+    main_tid = None
+    compositor_tid = None
+    audio_tid = None
+    worker_tids = []
+
+    if renderer_pid is not None:
+        for (pid, tid), name in tid_names.items():
+            if pid != renderer_pid:
+                continue
+            if name == 'CrRendererMain':
+                main_tid = tid
+            elif name == 'Compositor':
+                compositor_tid = tid
+            elif 'AudioWorklet' in name:
+                audio_tid = tid
+            elif name == 'DedicatedWorker thread':
+                worker_tids.append(tid)
+
+    return {
+        'pid_names': pid_names,
+        'tid_names': tid_names,
+        'worker_urls': worker_urls,
+        'ids': {
+            'renderer_pid': renderer_pid,
+            'main_tid': main_tid,
+            'compositor_tid': compositor_tid,
+            'audio_worklet_tid': audio_tid,
+            'worker_tids': sorted(set(worker_tids)),
+            'gpu_pid': gpu_pid,
+        },
+    }
+
+
+def collect_x(events, renderer_pid, tid=None):
+    out = []
+    if renderer_pid is None:
+        return out
+    for e in events:
+        if e.get('ph') != 'X':
+            continue
+        if e.get('pid') != renderer_pid:
+            continue
+        if tid is not None and e.get('tid') != tid:
+            continue
+        out.append(e)
+    return out
+
+
+def summarize_thread(events, renderer_pid, tid, label, long_task_ms=50, top=15):
+    if renderer_pid is None or tid is None:
+        return {
+            'tid': tid,
+            'label': label,
+            'event_count': 0,
+            'total_dur_ms': 0.0,
+            'long_tasks': {'threshold_ms': long_task_ms, 'count': 0, 'max_ms': 0.0},
+            'handle_post_message': {'count': 0, 'total_ms': 0.0, 'max_ms': 0.0, 'p95_ms': 0.0},
+            'top_names': [],
+        }
+
+    xs = collect_x(events, renderer_pid, tid)
+    total_ms = sum(to_float(e.get('dur')) for e in xs) / 1000.0
+    by_name = defaultdict(lambda: {'count': 0, 'total_us': 0.0, 'max_us': 0.0})
+    longs = []
+    hpm = []
+    threshold_us = long_task_ms * 1000.0
+
+    for e in xs:
+        name = str(e.get('name') or '?')
+        dur_us = to_float(e.get('dur'))
+        s = by_name[name]
+        s['count'] += 1
+        s['total_us'] += dur_us
+        s['max_us'] = max(s['max_us'], dur_us)
+        if dur_us >= threshold_us:
+            longs.append(dur_us / 1000.0)
+        if name == 'HandlePostMessage':
+            hpm.append(dur_us / 1000.0)
+
+    top_rows = sorted(by_name.items(), key=lambda kv: kv[1]['total_us'], reverse=True)[:top]
+    top_names = [
+        {
+            'name': n,
+            'count': int(s['count']),
+            'total_ms': round(s['total_us'] / 1000.0, 1),
+            'max_ms': round(s['max_us'] / 1000.0, 2),
+        }
+        for n, s in top_rows
+    ]
+
+    hpm_sorted = sorted(hpm)
+    return {
+        'tid': tid,
+        'label': label,
+        'event_count': len(xs),
+        'total_dur_ms': round(total_ms, 1),
+        'long_tasks': {
+            'threshold_ms': long_task_ms,
+            'count': len(longs),
+            'max_ms': round(max(longs), 2) if longs else 0.0,
+        },
+        'handle_post_message': {
+            'count': len(hpm),
+            'total_ms': round(sum(hpm), 1),
+            'max_ms': round(max(hpm), 2) if hpm else 0.0,
+            'p95_ms': round(percentile(hpm_sorted, 0.95), 2) if hpm else 0.0,
+        },
+        'top_names': top_names,
+    }
+
+def summarize_gc(events, renderer_pid):
+    if renderer_pid is None:
+        return {'count': 0, 'total_ms': 0.0, 'by_thread': {}}
+
+    by_thread = defaultdict(lambda: {'count': 0, 'total_us': 0.0, 'max_us': 0.0})
+    total_count = 0
+    total_us = 0.0
+
+    for e in collect_x(events, renderer_pid):
+        name = str(e.get('name') or '')
+        cat = str(e.get('cat') or '')
+        if 'gc' not in name.lower() and 'gc' not in cat.lower():
+            continue
+        tid = int(e.get('tid'))
+        dur_us = to_float(e.get('dur'))
+        s = by_thread[tid]
+        s['count'] += 1
+        s['total_us'] += dur_us
+        s['max_us'] = max(s['max_us'], dur_us)
+        total_count += 1
+        total_us += dur_us
+
+    payload = {
+        str(tid): {
+            'count': int(s['count']),
+            'total_ms': round(s['total_us'] / 1000.0, 1),
+            'max_ms': round(s['max_us'] / 1000.0, 2),
+        }
+        for tid, s in sorted(by_thread.items(), key=lambda kv: kv[1]['total_us'], reverse=True)
+    }
+    return {'count': total_count, 'total_ms': round(total_us / 1000.0, 1), 'by_thread': payload}
+
+
+def render_summary(main_summary, duration_s):
+    by_name = {r['name']: r for r in main_summary.get('top_names', [])}
+
+    def row(name):
+        r = by_name.get(name, {})
+        count = int(r.get('count', 0))
+        total_ms = to_float(r.get('total_ms'))
+        rate = count / duration_s if duration_s > 0 else 0.0
+        return {'count': count, 'total_ms': round(total_ms, 1), 'rate_per_s': round(rate, 2)}
+
+    return {
+        'fire_animation_frame': row('FireAnimationFrame'),
+        'page_animator_scripted': row('PageAnimator::serviceScriptedAnimations'),
+        'commit': row('Commit'),
+        'update_layout_tree': row('UpdateLayoutTree'),
+    }
+
+
+def audioworklet_intervals(events, renderer_pid, audio_tid):
+    if renderer_pid is None or audio_tid is None:
+        return {'event_name': None, 'count': 0}
+
+    xs = collect_x(events, renderer_pid, audio_tid)
+    run_a = [e for e in xs if str(e.get('name')) == 'RunTask']
+    run_b = [e for e in xs if str(e.get('name')) == 'ThreadControllerImpl::RunTask']
+    use = run_b if len(run_b) > len(run_a) else run_a
+
+    if len(use) < 2:
+        return {'event_name': 'RunTask', 'count': len(use)}
+
+    use = sorted(use, key=lambda e: to_float(e.get('ts')))
+    ts = [to_float(e.get('ts')) for e in use]
+    durs = [to_float(e.get('dur')) / 1000.0 for e in use]
+    intervals = [(ts[i + 1] - ts[i]) / 1000.0 for i in range(len(ts) - 1)]
+
+    durs_sorted = sorted(durs)
+    ints_sorted = sorted(intervals)
+
+    return {
+        'event_name': str(use[0].get('name')),
+        'count': len(use),
+        'duration_ms': {
+            'avg': round(mean(durs), 3),
+            'p95': round(percentile(durs_sorted, 0.95), 3),
+            'max': round(max(durs), 3),
+        },
+        'interval_ms': {
+            'avg': round(mean(intervals), 3),
+            'p50': round(percentile(ints_sorted, 0.5), 3),
+            'p95': round(percentile(ints_sorted, 0.95), 3),
+            'max': round(max(intervals), 3),
+        },
+    }
+
+
+def infer_worker_roles(worker_urls):
+    roles = {}
+    for tid, url in worker_urls.items():
+        low = url.lower()
+        if 'transcription.worker' in low:
+            roles['transcription'] = tid
+        elif 'tenvad.worker' in low:
+            roles['tenvad'] = tid
+        elif 'mel.worker' in low:
+            roles['mel'] = tid
+        elif 'buffer.worker' in low:
+            roles['buffer'] = tid
+    return roles
+
+
+def get_gc_ms(gc_summary, tid):
+    if tid is None:
+        return 0.0
+    return to_float((gc_summary.get('by_thread', {}).get(str(tid), {})).get('total_ms'))
+
+
+def mk_activity(threads):
+    rows = []
+    for t in threads:
+        rows.append({'label': t['label'], 'tid': t.get('tid'), 'total_dur_ms': t.get('total_dur_ms', 0.0)})
+    rows.sort(key=lambda x: to_float(x.get('total_dur_ms')), reverse=True)
+    return rows
+
+
+def compute_kpis(duration_s, main, render, aw_ints, thread_by_tid, roles, gc):
+    tx_tid = roles.get('transcription')
+    ten_tid = roles.get('tenvad')
+    mel_tid = roles.get('mel')
+
+    tx = thread_by_tid.get(tx_tid, {})
+    ten = thread_by_tid.get(ten_tid, {})
+    mel = thread_by_tid.get(mel_tid, {})
+
+    tx_long = tx.get('long_tasks', {})
+    awi = aw_ints.get('interval_ms', {})
+
+    return {
+        'trace_duration_s': round(duration_s, 2),
+        'main_total_ms': round(to_float(main.get('total_dur_ms')), 1),
+        'main_long_tasks_count': int(main.get('long_tasks', {}).get('count', 0)),
+        'fire_animation_frame_rate_per_s': round(to_float(render.get('fire_animation_frame', {}).get('rate_per_s')), 2),
+        'page_animator_total_ms': round(to_float(render.get('page_animator_scripted', {}).get('total_ms')), 1),
+        'transcription_worker_total_ms': round(to_float(tx.get('total_dur_ms')), 1),
+        'transcription_worker_gc_total_ms': round(get_gc_ms(gc, tx_tid), 1),
+        'transcription_worker_long_tasks_count': int(tx_long.get('count', 0)),
+        'transcription_worker_long_task_max_ms': round(to_float(tx_long.get('max_ms')), 2),
+        'tenvad_worker_total_ms': round(to_float(ten.get('total_dur_ms')), 1),
+        'mel_worker_total_ms': round(to_float(mel.get('total_dur_ms')), 1),
+        'audio_worklet_runtask_interval_p95_ms': round(to_float(awi.get('p95')), 3),
+        'audio_worklet_runtask_interval_max_ms': round(to_float(awi.get('max')), 3),
+    }
+
+
+def compare_kpis(current, baseline):
+    out = {}
+    keys = sorted(set(current.keys()) & set(baseline.keys()))
+    for k in keys:
+        c = current[k]
+        b = baseline[k]
+        if not isinstance(c, (int, float)) or not isinstance(b, (int, float)):
+            continue
+        delta = float(c) - float(b)
+        pct = None if b == 0 else round((delta / float(b)) * 100.0, 2)
+        out[k] = {
+            'baseline': b,
+            'current': c,
+            'delta_abs': round(delta, 3),
+            'delta_pct': pct,
+        }
+    return out
+
+def rank_bottlenecks(duration_s, main, thread_by_tid, roles, gc, render, aw_thread, aw_ints):
+    rows = []
+
+    tx_tid = roles.get('transcription')
+    tx = thread_by_tid.get(tx_tid)
+    if tx:
+        tx_total = to_float(tx.get('total_dur_ms'))
+        tx_gc = get_gc_ms(gc, tx_tid)
+        tx_long = tx.get('long_tasks', {})
+        tx_long_count = int(tx_long.get('count', 0))
+        tx_long_max = to_float(tx_long.get('max_ms'))
+        score = tx_total + tx_gc * 5 + tx_long_count * 6 + tx_long_max * 2
+        rows.append({
+            'category': 'transcription_worker_hot_path',
+            'title': 'Transcription worker hot path',
+            'score': round(score, 1),
+            'impact': 'Primary CPU and tail-latency source',
+            'evidence': {
+                'tid': tx_tid,
+                'total_dur_ms': round(tx_total, 1),
+                'share_of_trace_pct': round((tx_total / (duration_s * 1000.0)) * 100.0, 1) if duration_s > 0 else 0.0,
+                'long_tasks_over_threshold': tx_long_count,
+                'max_long_task_ms': round(tx_long_max, 2),
+                'gc_total_ms': round(tx_gc, 1),
+            },
+        })
+
+    main_total = to_float(main.get('total_dur_ms'))
+    raf = render.get('fire_animation_frame', {})
+    page = render.get('page_animator_scripted', {})
+    commit = render.get('commit', {})
+    layout = render.get('update_layout_tree', {})
+    render_score = (
+        main_total * 0.15
+        + to_float(page.get('total_ms'))
+        + to_float(commit.get('total_ms'))
+        + to_float(layout.get('total_ms'))
+        + to_float(raf.get('rate_per_s')) * 10
+    )
+    rows.append({
+        'category': 'main_thread_render_churn',
+        'title': 'Main-thread animation/render churn',
+        'score': round(render_score, 1),
+        'impact': 'Sustained UI CPU pressure',
+        'evidence': {
+            'total_dur_ms': round(main_total, 1),
+            'share_of_trace_pct': round((main_total / (duration_s * 1000.0)) * 100.0, 1) if duration_s > 0 else 0.0,
+            'fire_animation_frame_rate_per_s': raf.get('rate_per_s', 0.0),
+            'page_animator_total_ms': page.get('total_ms', 0.0),
+            'commit_total_ms': commit.get('total_ms', 0.0),
+            'update_layout_tree_total_ms': layout.get('total_ms', 0.0),
+        },
+    })
+
+    for role, title, impact in [
+        ('tenvad', 'TEN-VAD worker messaging/processing', 'Medium CPU load'),
+        ('mel', 'Mel worker messaging/processing', 'Medium CPU load'),
+        ('buffer', 'Buffer worker', 'Low impact currently'),
+    ]:
+        tid = roles.get(role)
+        ws = thread_by_tid.get(tid)
+        if not ws:
+            continue
+        hp = ws.get('handle_post_message', {})
+        total = to_float(ws.get('total_dur_ms'))
+        score = total + to_float(hp.get('total_ms')) * 2
+        rows.append({
+            'category': f'{role}_worker',
+            'title': title,
+            'score': round(score, 1),
+            'impact': impact,
+            'evidence': {
+                'tid': tid,
+                'total_dur_ms': round(total, 1),
+                'handle_post_message_count': int(hp.get('count', 0)),
+                'handle_post_message_total_ms': round(to_float(hp.get('total_ms')), 1),
+            },
+        })
+
+    aw_total = to_float(aw_thread.get('total_dur_ms')) if aw_thread else 0.0
+    aw_p95 = to_float(aw_ints.get('interval_ms', {}).get('p95'))
+    aw_max = to_float(aw_ints.get('interval_ms', {}).get('max'))
+    if aw_total > 0 or aw_p95 > 0:
+        score = aw_total + aw_p95 * 20 + aw_max * 5
+        rows.append({
+            'category': 'audio_worklet_scheduling',
+            'title': 'AudioWorklet scheduling pressure',
+            'score': round(score, 1),
+            'impact': 'Secondary jitter risk',
+            'evidence': {
+                'tid': aw_thread.get('tid') if aw_thread else None,
+                'total_dur_ms': round(aw_total, 1),
+                'interval_p95_ms': round(aw_p95, 3),
+                'interval_max_ms': round(aw_max, 3),
+            },
+        })
+
+    rows.sort(key=lambda x: to_float(x.get('score')), reverse=True)
+    for i, row in enumerate(rows, 1):
+        row['rank'] = i
+    return rows
+
+
+def build_markdown(summary):
+    lines = []
+    lines.append('# Trace Ultimate Report')
+    lines.append('')
+    lines.append(f"- Trace: `{summary['trace_file']}`")
+    lines.append(f"- Duration: `{summary['trace_duration_s']}s`")
+    lines.append(f"- Total events: `{summary['total_events']}`")
+    lines.append('')
+
+    lines.append('## Ranked Bottlenecks')
+    lines.append('')
+    lines.append('| Rank | Bottleneck | Impact | Key Evidence |')
+    lines.append('|---:|---|---|---|')
+    for row in summary.get('bottlenecks', []):
+        ev = row.get('evidence', {})
+        ev_bits = ', '.join([f"{k}={ev[k]}" for k in list(ev.keys())[:4]])
+        lines.append(f"| {row['rank']} | {row['title']} | {row['impact']} | {ev_bits} |")
+    lines.append('')
+
+    lines.append('## KPI Snapshot')
+    lines.append('')
+    lines.append('| KPI | Value |')
+    lines.append('|---|---:|')
+    for k, v in summary.get('kpis', {}).items():
+        lines.append(f'| `{k}` | {v} |')
+    lines.append('')
+
+    if summary.get('compare'):
+        lines.append('## Baseline Comparison')
+        lines.append('')
+        lines.append('| KPI | Baseline | Current | Delta | Delta % |')
+        lines.append('|---|---:|---:|---:|---:|')
+        for k, row in summary['compare'].items():
+            pct = '' if row['delta_pct'] is None else f"{row['delta_pct']:.2f}%"
+            lines.append(f"| `{k}` | {row['baseline']} | {row['current']} | {row['delta_abs']} | {pct} |")
+        lines.append('')
+
+    lines.append('## Thread Activity')
+    lines.append('')
+    lines.append('| Label | TID | Total ms |')
+    lines.append('|---|---:|---:|')
+    for row in summary.get('thread_activity', []):
+        lines.append(f"| {row['label']} | {row.get('tid', '')} | {row['total_dur_ms']} |")
+    lines.append('')
+
+    return '\n'.join(lines)
+
+
+def print_report(summary):
+    print('=' * 88)
+    print('KEET TRACE ULTIMATE ANALYZER')
+    print('=' * 88)
+    print(f"Trace file      : {summary['trace_file']}")
+    print(f"Trace duration  : {summary['trace_duration_s']}s")
+    print(f"Total events    : {summary['total_events']}")
+    ids = summary.get('thread_ids', {})
+    print(
+        'Renderer map    : '
+        f"pid={ids.get('renderer_pid')} main={ids.get('main_tid')} "
+        f"compositor={ids.get('compositor_tid')} audio={ids.get('audio_worklet_tid')}"
+    )
+    print('')
+
+    print('Top Thread Activity')
+    for row in summary.get('thread_activity', [])[:10]:
+        print(f"  {row['label']:<30} tid={str(row.get('tid')):<8} total={row['total_dur_ms']:>8}ms")
+
+    print('')
+    print('Ranked Bottlenecks')
+    for row in summary.get('bottlenecks', []):
+        ev = row.get('evidence', {})
+        ev_bits = ', '.join([f"{k}={ev[k]}" for k in list(ev.keys())[:4]])
+        print(f"  {row['rank']:>2}. {row['title']} | impact={row['impact']} | score={row['score']} | {ev_bits}")
+
+    print('')
+    print('KPI Snapshot')
+    for k, v in summary.get('kpis', {}).items():
+        print(f'  {k:<45} {v}')
+
+    if summary.get('compare'):
+        print('')
+        print('Baseline Delta')
+        for k, row in summary['compare'].items():
+            pct = 'n/a' if row['delta_pct'] is None else f"{row['delta_pct']:.2f}%"
+            print(f"  {k:<45} baseline={row['baseline']} current={row['current']} delta={row['delta_abs']} ({pct})")
+
+    print('=' * 88)
+
+def analyze(trace_path, baseline_json=None, long_task_ms=50, top=15):
+    events = load_trace(trace_path)
+    meta = build_meta(events)
+    ids = meta['ids']
+    renderer_pid = ids['renderer_pid']
+
+    threads = []
+    if ids['main_tid'] is not None:
+        threads.append(summarize_thread(events, renderer_pid, ids['main_tid'], 'Main Thread', long_task_ms, top))
+    if ids['compositor_tid'] is not None:
+        threads.append(summarize_thread(events, renderer_pid, ids['compositor_tid'], 'Compositor', long_task_ms, top))
+    if ids['audio_worklet_tid'] is not None:
+        threads.append(summarize_thread(events, renderer_pid, ids['audio_worklet_tid'], 'AudioWorklet', long_task_ms, top))
+    for tid in ids['worker_tids']:
+        threads.append(summarize_thread(events, renderer_pid, tid, f'Worker-{tid}', long_task_ms, top))
+
+    by_tid = {t['tid']: t for t in threads if t.get('tid') is not None}
+    main = next((t for t in threads if t['label'] == 'Main Thread'), {})
+    aw_thread = next((t for t in threads if t['label'] == 'AudioWorklet'), {})
+
+    gc = summarize_gc(events, renderer_pid)
+    roles = infer_worker_roles(meta['worker_urls'])
+    duration_s = trace_duration_s(events, renderer_pid=renderer_pid)
+    render = render_summary(main, duration_s)
+    aw_ints = audioworklet_intervals(events, renderer_pid, ids['audio_worklet_tid'])
+
+    bottlenecks = rank_bottlenecks(duration_s, main, by_tid, roles, gc, render, aw_thread, aw_ints)
+    kpis = compute_kpis(duration_s, main, render, aw_ints, by_tid, roles, gc)
+
+    compare = None
+    if baseline_json is not None:
+        with baseline_json.open('r', encoding='utf-8') as f:
+            baseline = json.load(f)
+        baseline_kpis = baseline.get('kpis', {}) if isinstance(baseline, dict) else {}
+        if isinstance(baseline_kpis, dict):
+            compare = compare_kpis(kpis, baseline_kpis)
+
+    summary = {
+        'version': 'ultimate-1.0',
+        'trace_file': trace_path.name,
+        'trace_path': str(trace_path),
+        'total_events': len(events),
+        'trace_duration_s': duration_s,
+        'thread_ids': ids,
+        'process_names': {str(pid): name for pid, name in meta['pid_names'].items()},
+        'thread_names': {f'{pid}:{tid}': name for (pid, tid), name in meta['tid_names'].items()},
+        'worker_urls_by_tid': {str(tid): url for tid, url in sorted(meta['worker_urls'].items())},
+        'worker_roles': roles,
+        'thread_activity': mk_activity(threads),
+        'threads': {str(t['tid']): t for t in threads if t.get('tid') is not None},
+        'gc': gc,
+        'render_loop': render,
+        'audio_worklet_intervals': aw_ints,
+        'bottlenecks': bottlenecks,
+        'kpis': kpis,
+        'compare': compare,
+    }
+    return summary
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description='Ultimate Chrome trace analyzer for Keet')
+    p.add_argument('trace_path', help='Input Chrome trace JSON path')
+    p.add_argument('--output-json', dest='output_json', help='Output JSON path')
+    p.add_argument('--output-md', dest='output_md', help='Output Markdown path')
+    p.add_argument('--baseline-json', dest='baseline_json', help='Baseline analyzer JSON path')
+    p.add_argument('--window-sec', dest='window_sec', type=int, default=30, help='Reserved for trend window size')
+    p.add_argument('--long-task-ms', dest='long_task_ms', type=int, default=50, help='Long task threshold in ms')
+    p.add_argument('--top', dest='top', type=int, default=15, help='Top rows per thread')
+    return p.parse_args()
+
+
+def run_cli(args):
+    trace_path = Path(args.trace_path)
+    if not trace_path.exists():
+        print(f'Error: trace file not found: {trace_path}')
+        return 1
+
+    baseline_path = Path(args.baseline_json) if args.baseline_json else None
+    if baseline_path is not None and not baseline_path.exists():
+        print(f'Error: baseline JSON not found: {baseline_path}')
+        return 1
+
+    summary = analyze(
+        trace_path=trace_path,
+        baseline_json=baseline_path,
+        long_task_ms=args.long_task_ms,
+        top=args.top,
+    )
+
+    print_report(summary)
+
+    out_json = Path(args.output_json) if args.output_json else trace_path.with_name('trace_ultimate_summary.json')
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    with out_json.open('w', encoding='utf-8') as f:
+        json.dump(summary, f, indent=2)
+    print(f'JSON written: {out_json}')
+
+    if args.output_md:
+        out_md = Path(args.output_md)
+        out_md.parent.mkdir(parents=True, exist_ok=True)
+        out_md.write_text(build_markdown(summary), encoding='utf-8')
+        print(f'Markdown written: {out_md}')
+
+    return 0
+
+
+def main():
+    return run_cli(parse_args())
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/src/components/Waveform.tsx
+++ b/src/components/Waveform.tsx
@@ -16,6 +16,13 @@ export const Waveform: Component<WaveformProps> = (props) => {
   let ctx: CanvasRenderingContext2D | null = null;
   let animationId: number | undefined;
   let resizeObserver: ResizeObserver | null = null;
+  let lastDrawTs = 0;
+  let lastStyleRefreshTs = 0;
+  let bgColor = '#faf8f5';
+  let strokeColor = '#14b8a6';
+  const FOREGROUND_FRAME_MS = 33;
+  const IDLE_FRAME_MS = 120;
+  const HIDDEN_FRAME_MS = 250;
 
   const updateCanvasSize = () => {
     if (!canvasRef?.parentElement) return;
@@ -29,9 +36,30 @@ export const Waveform: Component<WaveformProps> = (props) => {
     }
   };
 
-  const animate = () => {
+  const refreshThemeColors = () => {
+    if (!canvasRef) return;
+    const computed = getComputedStyle(canvasRef);
+    bgColor = computed.getPropertyValue('--color-earthy-bg').trim() || '#faf8f5';
+    strokeColor = computed.getPropertyValue('--color-primary').trim() || '#14b8a6';
+  };
+
+  const animate = (ts: number) => {
     animationId = requestAnimationFrame(animate);
     if (!ctx || !canvasRef) return;
+
+    const hidden = typeof document !== 'undefined' && document.visibilityState !== 'visible';
+    const minFrameInterval = hidden
+      ? HIDDEN_FRAME_MS
+      : props.isRecording
+        ? FOREGROUND_FRAME_MS
+        : IDLE_FRAME_MS;
+    if (ts - lastDrawTs < minFrameInterval) return;
+    lastDrawTs = ts;
+
+    if (ts - lastStyleRefreshTs > 1000) {
+      refreshThemeColors();
+      lastStyleRefreshTs = ts;
+    }
 
     const w = canvasRef.width;
     const h = canvasRef.height;
@@ -40,17 +68,14 @@ export const Waveform: Component<WaveformProps> = (props) => {
     const samples = props.barLevels;
     const n = samples && samples.length > 0 ? samples.length : 0;
 
-    const bg = getComputedStyle(canvasRef).getPropertyValue('--color-earthy-bg').trim() || '#faf8f5';
-    const color = getComputedStyle(canvasRef).getPropertyValue('--color-primary').trim() || '#14b8a6';
-
-    ctx.fillStyle = bg;
+    ctx.fillStyle = bgColor;
     ctx.fillRect(0, 0, w, h);
 
     if (props.isRecording && samples && n > 0) {
       const centerY = h / 2;
       const amp = (h / 2) * 0.9;
 
-      ctx.strokeStyle = color;
+      ctx.strokeStyle = strokeColor;
       ctx.lineWidth = 2;
       ctx.beginPath();
       ctx.moveTo(0, centerY - Math.max(-1, Math.min(1, samples[0])) * amp);
@@ -67,6 +92,7 @@ export const Waveform: Component<WaveformProps> = (props) => {
     if (canvasRef) {
       updateCanvasSize();
       ctx = canvasRef.getContext('2d', { alpha: false });
+      refreshThemeColors();
       if (resizeObserver = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(updateCanvasSize) : null) {
         resizeObserver.observe(canvasRef.parentElement ?? canvasRef);
       }
@@ -75,7 +101,9 @@ export const Waveform: Component<WaveformProps> = (props) => {
   });
 
   onCleanup(() => {
-    cancelAnimationFrame(animationId!);
+    if (animationId !== undefined) {
+      cancelAnimationFrame(animationId);
+    }
     resizeObserver?.disconnect();
   });
 

--- a/src/lib/transcription/TranscriptionWorkerClient.ts
+++ b/src/lib/transcription/TranscriptionWorkerClient.ts
@@ -109,6 +109,10 @@ export class TranscriptionWorkerClient {
         });
     }
 
+    private transferList(buffer: ArrayBufferLike, transferOwnership?: boolean): Transferable[] {
+        return transferOwnership === false ? [] : [buffer as ArrayBuffer];
+    }
+
     // API Methods
     async initModel(modelId?: string): Promise<void> {
         return this.sendRequest('INIT_MODEL', { modelId });
@@ -126,14 +130,24 @@ export class TranscriptionWorkerClient {
         return this.sendRequest('INIT_V3_SERVICE', { config });
     }
 
-    async processChunk(audio: Float32Array): Promise<TranscriptionResult> {
-        // Transfer audio buffer
-        return this.sendRequest('PROCESS_CHUNK', audio, [audio.buffer]);
+    /**
+     * Default behavior transfers `audio.buffer` to worker ownership.
+     * Pass `transferOwnership: false` when the caller must keep using `audio`.
+     */
+    async processChunk(audio: Float32Array, options: { transferOwnership?: boolean } = {}): Promise<TranscriptionResult> {
+        return this.sendRequest('PROCESS_CHUNK', audio, this.transferList(audio.buffer, options.transferOwnership));
     }
 
-    async processV3Chunk(audio: Float32Array, startTime?: number): Promise<TokenStreamResult> {
-        // Transfer audio buffer
-        return this.sendRequest('PROCESS_V3_CHUNK', { audio, startTime }, [audio.buffer]);
+    /**
+     * Default behavior transfers `audio.buffer` to worker ownership.
+     * Pass `transferOwnership: false` when the caller must keep using `audio`.
+     */
+    async processV3Chunk(
+        audio: Float32Array,
+        startTime?: number,
+        options: { transferOwnership?: boolean } = {},
+    ): Promise<TokenStreamResult> {
+        return this.sendRequest('PROCESS_V3_CHUNK', { audio, startTime }, this.transferList(audio.buffer, options.transferOwnership));
     }
 
     /**
@@ -146,16 +160,19 @@ export class TranscriptionWorkerClient {
         melBins: number,
         startTime?: number,
         overlapSeconds?: number,
+        options: { transferOwnership?: boolean } = {},
     ): Promise<TokenStreamResult> {
-        // Transfer features buffer
         return this.sendRequest('PROCESS_V3_CHUNK_WITH_FEATURES', {
             features, T, melBins, startTime, overlapSeconds,
-        }, [features.buffer]);
+        }, this.transferList(features.buffer, options.transferOwnership));
     }
 
-    async transcribeSegment(audio: Float32Array): Promise<TranscriptionResult> {
-        // Transfer audio buffer
-        return this.sendRequest('TRANSCRIBE_SEGMENT', audio, [audio.buffer]);
+    /**
+     * Default behavior transfers `audio.buffer` to worker ownership.
+     * Pass `transferOwnership: false` when the caller must keep using `audio`.
+     */
+    async transcribeSegment(audio: Float32Array, options: { transferOwnership?: boolean } = {}): Promise<TranscriptionResult> {
+        return this.sendRequest('TRANSCRIBE_SEGMENT', audio, this.transferList(audio.buffer, options.transferOwnership));
     }
 
     async reset(): Promise<void> {
@@ -187,9 +204,14 @@ export class TranscriptionWorkerClient {
         endTime?: number;
         segmentId?: string;
         incrementalCache?: V4IncrementalCache;
+        transferOwnership?: boolean;
     }): Promise<V4ProcessResult> {
-        // Transfer features buffer
-        return this.sendRequest('PROCESS_V4_CHUNK_WITH_FEATURES', params, [params.features.buffer]);
+        const { transferOwnership, ...payload } = params;
+        return this.sendRequest(
+            'PROCESS_V4_CHUNK_WITH_FEATURES',
+            payload,
+            this.transferList(payload.features.buffer, transferOwnership),
+        );
     }
 
     /**

--- a/src/lib/transcription/UtteranceBasedMerger.regression.test.ts
+++ b/src/lib/transcription/UtteranceBasedMerger.regression.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from 'vitest';
+import { UtteranceBasedMerger, type ASRWord } from './UtteranceBasedMerger';
+
+type WordTuple = [text: string, start: number, end?: number];
+
+function wordsFromTuples(tuples: WordTuple[]): ASRWord[] {
+    return tuples.map(([text, start, end]) => ({
+        text,
+        start_time: start,
+        end_time: end ?? start + 0.4,
+        confidence: 0.9,
+    }));
+}
+
+function asrFromTuples(tuples: WordTuple[]) {
+    const words = wordsFromTuples(tuples);
+    return {
+        utterance_text: words.map((w) => w.text).join(' '),
+        words,
+        end_time: words.length > 0 ? words[words.length - 1].end_time : 0,
+    };
+}
+
+function createMerger() {
+    return new UtteranceBasedMerger({
+        useNLP: false,
+        debug: false,
+    });
+}
+
+describe('UtteranceBasedMerger streaming regression fixtures', () => {
+    test('partial-to-full merging and overlap conflict resolution remain coherent', () => {
+        const merger = createMerger();
+
+        const fixtures = [
+            {
+                words: [
+                    ['hello', 0.0, 0.4],
+                    ['there', 0.4, 0.8],
+                ] as WordTuple[],
+                expected: { mature: '', immature: 'hello there', full: 'hello there', cursor: 0.0 },
+            },
+            {
+                words: [
+                    ['hello', 0.0, 0.4],
+                    ['there.', 0.4, 0.8],
+                    ['how', 0.8, 1.1],
+                ] as WordTuple[],
+                expected: { mature: 'hello there.', immature: 'how', full: 'hello there. how', cursor: 0.8 },
+            },
+            {
+                words: [
+                    ['hello', 0.0, 0.4],
+                    ['there.', 0.4, 0.8],
+                    ['how', 0.8, 1.1],
+                    ['are', 1.1, 1.4],
+                    ['you', 1.4, 1.8],
+                ] as WordTuple[],
+                expected: { mature: 'hello there.', immature: 'how are you', full: 'hello there. how are you', cursor: 0.8 },
+            },
+            {
+                words: [
+                    ['hello', 0.0, 0.4],
+                    ['there.', 0.4, 0.8],
+                    ['how', 0.8, 1.1],
+                    ['are', 1.1, 1.4],
+                    ['you?', 1.4, 1.8],
+                    ['next', 1.8, 2.2],
+                ] as WordTuple[],
+                expected: {
+                    mature: 'hello there. how are you?',
+                    immature: 'next',
+                    full: 'hello there. how are you? next',
+                    cursor: 1.8,
+                },
+            },
+        ];
+
+        for (const fixture of fixtures) {
+            const result = merger.processASRResult(asrFromTuples(fixture.words));
+            expect(result.matureText).toBe(fixture.expected.mature);
+            expect(result.immatureText).toBe(fixture.expected.immature);
+            expect(result.fullText).toBe(fixture.expected.full);
+            expect(result.matureCursorTime).toBe(fixture.expected.cursor);
+        }
+    });
+
+    test('punctuation/case restoration from overlapping windows keeps latest coherent sentence text', () => {
+        const merger = createMerger();
+
+        merger.processASRResult(
+            asrFromTuples([
+                ['good', 0.0, 0.3],
+                ['morning', 0.3, 0.7],
+                ['everyone', 0.7, 1.1],
+            ]),
+        );
+
+        const refined = merger.processASRResult(
+            asrFromTuples([
+                ['Good', 0.0, 0.3],
+                ['morning', 0.3, 0.7],
+                ['everyone.', 0.7, 1.1],
+                ['today', 1.1, 1.4],
+            ]),
+        );
+
+        expect(refined.matureText).toBe('Good morning everyone.');
+        expect(refined.immatureText).toBe('today');
+        expect(refined.fullText).toBe('Good morning everyone. today');
+    });
+
+    test('repeated words, delayed tokens, and retranscription overlap stay deduped', () => {
+        const merger = createMerger();
+
+        const first = merger.processASRResult(
+            asrFromTuples([
+                ['I', 0.0, 0.3],
+                ['I', 0.3, 0.6],
+                ['think', 0.6, 1.0],
+            ]),
+        );
+        expect(first.immatureText).toBe('I I think');
+
+        const corrected = merger.processASRResult(
+            asrFromTuples([
+                ['I', 0.0, 0.3],
+                ['think', 0.3, 0.8],
+                ['this', 0.8, 1.2],
+            ]),
+        );
+        expect(corrected.immatureText).toBe('I think this');
+
+        const completed = merger.processASRResult(
+            asrFromTuples([
+                ['I', 0.0, 0.3],
+                ['think', 0.3, 0.8],
+                ['this', 0.8, 1.2],
+                ['works.', 1.2, 1.6],
+                ['now', 1.6, 2.0],
+            ]),
+        );
+        expect(completed.matureText).toBe('I think this works.');
+        expect(completed.immatureText).toBe('now');
+
+        const staleOverlap = merger.processASRResult(
+            asrFromTuples([
+                ['I', 0.0, 0.3],
+                ['think', 0.3, 0.82],
+                ['this', 0.82, 1.18],
+                ['works.', 1.18, 1.62],
+                ['now', 1.62, 2.02],
+                ['again', 2.02, 2.4],
+            ]),
+        );
+        expect(staleOverlap.matureText).toBe('I think this works.');
+        expect(staleOverlap.immatureText).toBe('now again');
+        expect(staleOverlap.allMatureSentences).toHaveLength(1);
+    });
+
+    test('short pause does not flush incomplete sentence, long pause flushes complete one', () => {
+        const merger = createMerger();
+
+        merger.processASRResult(
+            asrFromTuples([
+                ['we', 0.0, 0.3],
+                ['are', 0.3, 0.6],
+                ['testing', 0.6, 1.0],
+            ]),
+        );
+        expect(merger.finalizePendingSentenceByTimeout()).toBeNull();
+
+        merger.processASRResult(
+            asrFromTuples([
+                ['we', 0.0, 0.3],
+                ['are', 0.3, 0.6],
+                ['testing.', 0.6, 1.0],
+            ]),
+        );
+        const flushed = merger.finalizePendingSentenceByTimeout();
+        expect(flushed).not.toBeNull();
+        expect(flushed?.matureText).toBe('we are testing.');
+        expect(flushed?.immatureText).toBe('');
+    });
+});
+

--- a/src/lib/transcription/WindowBuilder.test.ts
+++ b/src/lib/transcription/WindowBuilder.test.ts
@@ -60,6 +60,20 @@ describe('WindowBuilder', () => {
             expect(win!.startFrame).toBe(0);
             expect(win!.durationSeconds).toBeGreaterThanOrEqual(1.5);
         });
+
+        it('should clamp stale start hint to ring base', () => {
+            const ring = createMockRingBuffer(sampleRate * 10, sampleRate * 14);
+            const builder = new WindowBuilder(ring, null, {
+                sampleRate,
+                minDurationSec: 3,
+                maxDurationSec: 30,
+                minInitialDurationSec: 1.0,
+            });
+
+            const win = builder.buildWindow(sampleRate * 4);
+            expect(win).not.toBeNull();
+            expect(win!.startFrame).toBe(sampleRate * 10);
+        });
     });
 
     describe('mature cursor and sentence bookkeeping', () => {

--- a/src/lib/transcription/WindowBuilder.ts
+++ b/src/lib/transcription/WindowBuilder.ts
@@ -159,15 +159,19 @@ export class WindowBuilder {
      * The caller should use the returned startFrame/endFrame to extract audio
      * from the ring buffer and request mel features from the mel worker.
      */
-    buildWindow(): TranscriptionWindow | null {
+    buildWindow(startHintFrame?: number): TranscriptionWindow | null {
         const endFrame = this.ringBuffer.getCurrentFrame();
         const baseFrame = this.ringBuffer.getBaseFrameOffset();
+        const clampedStartHint = startHintFrame !== undefined
+            ? Math.min(endFrame, Math.max(baseFrame, Math.floor(startHintFrame)))
+            : undefined;
 
         if (endFrame === baseFrame) {
             return null; // no data
         }
 
-        const availableFrames = endFrame - baseFrame;
+        const initialStartFrame = clampedStartHint ?? baseFrame;
+        const availableFrames = endFrame - initialStartFrame;
 
         // ---- Initial mode (before first sentence) ----
         if (!this.firstSentenceReceived) {
@@ -185,19 +189,19 @@ export class WindowBuilder {
                 return null;
             }
 
-            // Start from base, up to max duration
+            // Start from base (or hint), up to max duration
             const maxFrames = Math.round(this.config.maxDurationSec * this.config.sampleRate);
-            const clippedEnd = Math.min(endFrame, baseFrame + maxFrames);
-            const duration = (clippedEnd - baseFrame) / this.config.sampleRate;
+            const clippedEnd = Math.min(endFrame, initialStartFrame + maxFrames);
+            const duration = (clippedEnd - initialStartFrame) / this.config.sampleRate;
 
             if (this.config.debug) {
                 console.log(
-                    `[WindowBuilder] Initial window [${baseFrame}:${clippedEnd}] (${duration.toFixed(2)}s)`
+                    `[WindowBuilder] Initial window [${initialStartFrame}:${clippedEnd}] (${duration.toFixed(2)}s)`
                 );
             }
 
             return {
-                startFrame: baseFrame,
+                startFrame: initialStartFrame,
                 endFrame: clippedEnd,
                 durationSeconds: duration,
                 isInitial: true,
@@ -216,6 +220,15 @@ export class WindowBuilder {
             startFrame = this.sentenceEnds[0];
         } else {
             startFrame = baseFrame;
+        }
+
+        if (clampedStartHint !== undefined && startFrame < clampedStartHint) {
+            if (this.config.debug) {
+                console.log(
+                    `[WindowBuilder] Applying start hint: ${startFrame} -> ${clampedStartHint}`
+                );
+            }
+            startFrame = clampedStartHint;
         }
 
         // Ensure start frame is within valid buffer range

--- a/src/lib/transcription/transcription.worker.ts
+++ b/src/lib/transcription/transcription.worker.ts
@@ -225,8 +225,7 @@ self.onmessage = async (e: MessageEvent) => {
                         melBins: payload.melBins,
                     },
                     returnTimestamps: true,
-                    returnTokenIds: true,
-                    returnFrameIndices: true,
+                    enableProfiling: false,
                     timeOffset: payload.timeOffset || 0,
                     // Incremental decoder cache for the overlap prefix
                     ...(payload.incrementalCache ? {


### PR DESCRIPTION
**Summary:**
Improves the streaming transcription runtime by reducing worker/message overhead, cutting UI/render churn, and adding profiling tooling for Chrome traces and heap captures. Also restores streaming merge correctness and adds regression tests to prevent semantic regressions while optimizing.

**Changes:**
- Reduce hot-path overhead by disabling heavy logging/profiling in v4/mel paths
- Reduce UI/visualization churn with throttled waveform drawing and visibility-aware update cadence
- Optimize BufferWorker copy paths and add coverage for query/range behavior
- Use Transferables in TranscriptionWorkerClient to reduce structured-clone `postMessage` overhead
- Restore streaming merge semantics (cursor-anchored windowing) and add cache-prefix safety guard
- Add regression protection: `UtteranceBasedMerger.regression.test.ts` and WindowBuilder tests
- Add tooling: `metrics/trace_ultimate.py`, `metrics/analyze_chrome_trace.py`, `metrics/memory/analyze_heap_memory.py`

**Performance impact:**
- Before: Not provided (measured locally only)
- After: Not provided (measured locally only)
- Notes: Intended effects are lower worker-message overhead, less UI churn, and better memory/GC visibility via trace/heap analyzers.

**Risk & compatibility:**
- Worker messaging changes (Transferables) can surface ownership/lifetime assumptions for buffers
- Window/caching guardrails are correctness-sensitive; intended to preserve transcript semantics and avoid invalid cache reuse
- Intentionally unchanged: transcript merge semantics (explicitly restored + regression tests)

**How to test:**
1. `npm install`
2. `npm test`
3. `npm run build`
4. Optional (trace): `python metrics/trace_ultimate.py <trace.json>` or `python metrics/analyze_chrome_trace.py <trace.json>`
5. Optional (heap): `python metrics/memory/analyze_heap_memory.py --inputs "traces/heaps/*" --report-md traces/heaps/memory_report_pass1.md --report-json traces/heaps/memory_report_pass1.json --top-n 25 --pairwise --strict-validate`

**Checklist:**
- [ ] Tests added/updated
- [ ] Existing tests pass
- [ ] Benchmarks captured (if applicable)
- [ ] Docs/comments updated (if applicable)

**Notes:**
Review focus: worker transferables, BufferWorker copy/retention behavior, and the UtteranceBasedMerger regression suite locking in transcript semantics.

Closes #110
Closes #113
Related: #117 (partially addressed)
Related: #73 (partially addressed)
Related: #105, #92, #141
