### PR TITLE
perf: conservative round 2 optimizations (buffer/ui/debug)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -559,6 +559,9 @@ const App: Component = () => {
     v4InferenceBusy = false;
     v4LastInferenceTime = 0;
     v4GlobalSampleOffset = 0;
+    v4CacheTelemetry.enabled = 0;
+    v4CacheTelemetry.bypassNonPositivePrefix = 0;
+    v4CacheTelemetry.bypassOutsideWindow = 0;
   };
 
   const toggleRecording = async () => {

--- a/src/components/LayeredBufferVisualizer.tsx
+++ b/src/components/LayeredBufferVisualizer.tsx
@@ -82,6 +82,7 @@ export const LayeredBufferVisualizer: Component<LayeredBufferVisualizerProps> = 
     let cachedDpr = window.devicePixelRatio || 1;
     let resizeObserver: ResizeObserver | null = null;
     let dprMediaQuery: MediaQueryList | null = null;
+    let dprChangeHandler: ((this: MediaQueryList, ev: MediaQueryListEvent) => any) | null = null;
 
     /** Recompute physical canvas dimensions from cached logical size + DPR. */
     const updateCanvasDimensions = (logicalW: number, logicalH: number) => {
@@ -138,6 +139,9 @@ export const LayeredBufferVisualizer: Component<LayeredBufferVisualizerProps> = 
 
             // Watch for DPR changes (browser zoom, display change)
             const setupDprWatch = () => {
+                if (dprMediaQuery && dprChangeHandler) {
+                    dprMediaQuery.removeEventListener('change', dprChangeHandler);
+                }
                 dprMediaQuery = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
                 const onDprChange = () => {
                     if (disposed) return;
@@ -148,6 +152,7 @@ export const LayeredBufferVisualizer: Component<LayeredBufferVisualizerProps> = 
                     // Re-register for the next change at the new DPR
                     setupDprWatch();
                 };
+                dprChangeHandler = onDprChange;
                 dprMediaQuery.addEventListener('change', onDprChange, { once: true });
             };
             setupDprWatch();
@@ -171,6 +176,11 @@ export const LayeredBufferVisualizer: Component<LayeredBufferVisualizerProps> = 
             resizeObserver.disconnect();
             resizeObserver = null;
         }
+        if (dprMediaQuery && dprChangeHandler) {
+            dprMediaQuery.removeEventListener('change', dprChangeHandler);
+        }
+        dprMediaQuery = null;
+        dprChangeHandler = null;
     });
 
     const loop = (now: number = performance.now()) => {

--- a/src/components/TranscriptionDisplay.tsx
+++ b/src/components/TranscriptionDisplay.tsx
@@ -150,12 +150,19 @@ export const TranscriptionDisplay: Component<TranscriptionDisplayProps> = (props
 
     const finalizedEntries = createMemo(() => props.sentenceEntries ?? []);
     const mergedCount = createMemo(() => finalizedEntries().length + (props.pendingText?.trim() ? 1 : 0));
-    const fullTextBody = createMemo(() => {
-        const finalized = finalizedEntries()
+    const finalizedMergedText = createMemo(() => {
+        // Avoid rebuilding the full finalized corpus while user is on Live tab.
+        if (props.isV4Mode && activeTab() !== 'merged') {
+            return '';
+        }
+        return finalizedEntries()
             .map((entry) => entry.text.trim())
             .filter((text) => text.length > 0)
             .join(' ')
             .trim();
+    });
+    const fullTextBody = createMemo(() => {
+        const finalized = finalizedMergedText();
         const live = props.pendingText.trim();
         if (finalized && live) return `${finalized} ${live}`.trim();
         return finalized || live || '';

--- a/src/lib/buffer/BufferWorkerClient.ts
+++ b/src/lib/buffer/BufferWorkerClient.ts
@@ -10,6 +10,7 @@ import type {
     BufferWorkerConfig,
     BufferWorkerResponse,
     HasSpeechResult,
+    VadSummaryResult,
     RangeResult,
     BufferState,
 } from './types';
@@ -133,6 +134,23 @@ export class BufferWorkerClient {
         threshold: number,
     ): Promise<HasSpeechResult> {
         return this.sendRequest('HAS_SPEECH', { layer, startSample, endSample, threshold });
+    }
+
+    /**
+     * Consolidated VAD query used by v4Tick to reduce worker round-trips.
+     * Preserves existing semantics:
+     * - requireInference=true => energy && inference
+     * - requireInference=false => energy only
+     * - silence tail always computed from energy layer
+     */
+    async getVadSummary(params: {
+        startSample: number;
+        endSample: number;
+        energyThreshold: number;
+        inferenceThreshold: number;
+        requireInference: boolean;
+    }): Promise<VadSummaryResult> {
+        return this.sendRequest('GET_VAD_SUMMARY', params);
     }
 
     /**

--- a/src/lib/buffer/BufferWorkerClient.ts
+++ b/src/lib/buffer/BufferWorkerClient.ts
@@ -10,6 +10,7 @@ import type {
     BufferWorkerConfig,
     BufferWorkerResponse,
     HasSpeechResult,
+    VadSummaryQuery,
     VadSummaryResult,
     RangeResult,
     BufferState,
@@ -143,13 +144,7 @@ export class BufferWorkerClient {
      * - requireInference=false => energy only
      * - silence tail always computed from energy layer
      */
-    async getVadSummary(params: {
-        startSample: number;
-        endSample: number;
-        energyThreshold: number;
-        inferenceThreshold: number;
-        requireInference: boolean;
-    }): Promise<VadSummaryResult> {
+    async getVadSummary(params: VadSummaryQuery): Promise<VadSummaryResult> {
         return this.sendRequest('GET_VAD_SUMMARY', params);
     }
 

--- a/src/lib/buffer/types.ts
+++ b/src/lib/buffer/types.ts
@@ -36,6 +36,7 @@ export type BufferWorkerRequest =
     | { type: 'WRITE'; id?: number; payload: WritePayload }
     | { type: 'WRITE_BATCH'; id?: number; payload: WriteBatchPayload }
     | { type: 'HAS_SPEECH'; id: number; payload: HasSpeechQuery }
+    | { type: 'GET_VAD_SUMMARY'; id: number; payload: VadSummaryQuery }
     | { type: 'GET_SILENCE_TAIL'; id: number; payload: SilenceTailQuery }
     | { type: 'QUERY_RANGE'; id: number; payload: RangeQuery }
     | { type: 'GET_STATE'; id: number; payload?: undefined }
@@ -80,6 +81,20 @@ export interface HasSpeechQuery {
     threshold: number;
 }
 
+/** Consolidated VAD query used by v4Tick to reduce worker round-trips. */
+export interface VadSummaryQuery {
+    /** Start sample (global, inclusive) */
+    startSample: number;
+    /** End sample (global, exclusive) */
+    endSample: number;
+    /** Energy VAD threshold */
+    energyThreshold: number;
+    /** Inference VAD threshold */
+    inferenceThreshold: number;
+    /** If true, speech requires energy && inference; otherwise energy only */
+    requireInference: boolean;
+}
+
 /** Query data for an arbitrary sample range. */
 export interface RangeQuery {
     /** Start sample (global, inclusive) */
@@ -95,6 +110,7 @@ export interface RangeQuery {
 export type BufferWorkerResponse =
     | { type: 'INIT'; id: number; payload: { success: boolean } }
     | { type: 'HAS_SPEECH'; id: number; payload: HasSpeechResult }
+    | { type: 'GET_VAD_SUMMARY'; id: number; payload: VadSummaryResult }
     | { type: 'GET_SILENCE_TAIL'; id: number; payload: { durationSec: number } }
     | { type: 'QUERY_RANGE'; id: number; payload: RangeResult }
     | { type: 'GET_STATE'; id: number; payload: BufferState }
@@ -105,6 +121,13 @@ export interface HasSpeechResult {
     hasSpeech: boolean;
     maxProb: number;
     entriesChecked: number;
+}
+
+export interface VadSummaryResult {
+    energy: HasSpeechResult;
+    inference: HasSpeechResult | null;
+    hasSpeech: boolean;
+    silenceTailDurationSec: number;
 }
 
 export interface RangeResult {

--- a/traces/notes/TOMORROW_OPTIMIZATIONS.md
+++ b/traces/notes/TOMORROW_OPTIMIZATIONS.md
@@ -61,7 +61,7 @@ Context:
 - `#2` Worker response payload slimming:
   - Deferred in this conservative pass to avoid v4 worker payload/interface churn and regression risk.
 - `#4` Mel feature transfer reuse/pooling:
-  - Deferred due higher risk around transferable ownership and cross-worker lifecycle coordination.
+  - Deferred due to higher risk around transferable ownership and cross-worker lifecycle coordination.
 
 ### TODO
 - Revisit `#2` with explicit payload contract/perf benchmarks before changing worker response shapes.

--- a/traces/notes/TOMORROW_OPTIMIZATIONS.md
+++ b/traces/notes/TOMORROW_OPTIMIZATIONS.md
@@ -1,0 +1,72 @@
+# Tomorrow Optimization Handoff (2026-02-18)
+
+Context:
+- Streaming merge correctness regression was fixed in commit `c0b5c3f`.
+- Preserve merge semantics first; only apply non-semantic performance optimizations.
+
+## Prioritized Next Optimizations
+
+1. BufferWorker round-trip reduction (Low risk, Medium impact)
+- In `v4Tick`, replace multiple async worker calls (`hasSpeech` energy + inference + silence tail)
+  with one consolidated request returning required VAD state for `[cursor, current]`.
+- Goal: reduce main<->worker message overhead and latency jitter.
+
+2. Worker response payload slimming (Low risk, Medium impact)
+- In `PROCESS_V4_CHUNK_WITH_FEATURES_DONE`, send only deltas for sentence entries
+  and avoid repeating unchanged heavy fields each tick.
+- Goal: reduce structured clone/message transfer overhead.
+
+3. UI render containment for transcript pane (Low risk, Medium impact)
+- Ensure only changed transcript segments re-render.
+- Avoid full text reconciliation when only immature tail changes.
+
+4. Mel feature transfer reuse/pooling (Low risk, Medium impact)
+- Reuse transferable buffers between mel worker and transcription worker where possible.
+- Goal: lower allocation churn and GC pressure.
+
+5. Debug panel hard-off path (Low risk, Low/Medium impact)
+- Verify hidden debug panel does zero compute (no chart updates/data transforms).
+
+6. Incremental cache telemetry guardrails (Low risk, Safety/Observability)
+- Keep cache prefix validity guard.
+- Add counters/log sampling for cache-hit/cache-bypass reasons.
+
+## Guardrails
+- Do not alter sentence merge semantics.
+- Keep `UtteranceBasedMerger` regression fixtures green.
+- If optimization conflicts with transcript coherence, disable optimization.
+
+## Validation Checklist (each optimization)
+- `npm test -- src/lib/transcription/WindowBuilder.test.ts src/lib/transcription/UtteranceBasedMerger.test.ts src/lib/transcription/UtteranceBasedMerger.regression.test.ts`
+- `npm test`
+- `npm run build`
+- Optional trace compare with `metrics/trace_ultimate.py` when profiling session is available.
+
+## DONE / SKIPPED / TODO (Round 2 - 2026-02-18)
+
+### DONE
+- `#1` BufferWorker round-trip reduction:
+  - Added consolidated `GET_VAD_SUMMARY` worker query and switched `v4Tick` to one call for energy speech, optional inference speech, and energy silence tail.
+  - Existing `HAS_SPEECH` and `GET_SILENCE_TAIL` APIs were kept for compatibility.
+- `#3` UI render containment for transcript pane:
+  - Batched v4 UI/store updates in `App.tsx` to reduce reactive churn per inference tick.
+  - `TranscriptionDisplay` now skips rebuilding merged finalized corpus while `Live` tab is active.
+- `#5` Debug panel hard-off path:
+  - Added unmount/dispose guards in `LayeredBufferVisualizer` so pending async callbacks and animation loop do no work after panel close/unmount.
+- `#6` Incremental cache telemetry guardrails:
+  - Kept existing cache prefix validity guard.
+  - Added sampled counters/logging for `enabled`, `bypassNonPositivePrefix`, and `bypassOutsideWindow`.
+
+### SKIPPED
+- `#2` Worker response payload slimming:
+  - Deferred in this conservative pass to avoid v4 worker payload/interface churn and regression risk.
+- `#4` Mel feature transfer reuse/pooling:
+  - Deferred due higher risk around transferable ownership and cross-worker lifecycle coordination.
+
+### TODO
+- Revisit `#2` with explicit payload contract/perf benchmarks before changing worker response shapes.
+- Revisit `#4` behind an opt-in flag after adding dedicated transfer-lifetime tests and profiling proof.
+
+### Merger Safety Note
+- No text merge algorithm paths were optimized/refactored in this round.
+- `UtteranceBasedMerger` semantics intentionally unchanged.


### PR DESCRIPTION
## Summary
Implements conservative Performance Round 2 optimizations from `traces/notes/TOMORROW_OPTIMIZATIONS.md` with low-risk, incremental changes and no merger-logic modifications.

## What Changed
- Consolidated v4 VAD polling into one BufferWorker request (`GET_VAD_SUMMARY`) and switched `v4Tick` from multiple worker calls to a single summary call.
- Preserved semantics:
  - Inference-ready path still requires `energy && inference`.
  - Fallback path remains energy-only.
  - Silence tail remains energy-based.
- Reduced transcript-pane reactive churn:
  - Batched v4 store updates in `App.tsx`.
  - Skipped merged finalized-text rebuild while `Live` tab is active.
- Hardened DebugPanel off-path behavior:
  - Added unmount/dispose guards for async callbacks and rAF in `LayeredBufferVisualizer`.
  - Added explicit DPR media-query listener cleanup on unmount.
- Added incremental cache telemetry guardrails:
  - Counters + sampled logging for cache enabled and bypass reasons.
- Updated `traces/notes/TOMORROW_OPTIMIZATIONS.md` with DONE/SKIPPED/TODO for this round.

## Scope Decisions
- Done: #1, #3, #5, #6 from `TOMORROW_OPTIMIZATIONS.md`
- Deferred: #2 payload slimming, #4 mel transfer reuse/pooling
- Explicitly avoided: text merge algorithm changes (`UtteranceBasedMerger` semantics unchanged)

## Validation
- `npm test -- src/lib/transcription/WindowBuilder.test.ts src/lib/transcription/UtteranceBasedMerger.test.ts src/lib/transcription/UtteranceBasedMerger.regression.test.ts`
- `npm test -- src/lib/buffer/buffer.worker.test.ts`
- `npm test -- src/stores/appStore.test.ts`
- `npm test -- src/lib/vad/tenvad.worker.test.ts`
- `npm test`
- `npm run build`

## Issue/PR Links
Closes #131
Related: #116, #73, #27
Related PRs: #141, #138, #92

## Summary by Sourcery

Optimize v4 streaming transcription performance and debug UI behavior with conservative, non-semantic changes.

New Features:
- Add consolidated GET_VAD_SUMMARY buffer worker API to return combined energy/inference VAD results and energy-based silence tail in a single call.
- Introduce incremental cache telemetry counters and sampled logging for v4 decoder cache usage and bypass reasons.

Enhancements:
- Reduce v4Tick worker round-trips by switching VAD polling to the new consolidated summary API while preserving existing speech and silence semantics.
- Batch v4-related store updates and avoid rebuilding the merged finalized transcript while the Live tab is active to cut reactive UI churn.
- Harden LayeredBufferVisualizer cleanup and DPR change handling so animation frames and async callbacks do no work after unmount or panel closure.
- Record v4 buffer metrics, merger stats, latency, and RTF updates in a single batched UI update to minimize render overhead.
- Add design notes documenting completed, deferred, and skipped performance optimizations for this round.

Documentation:
- Add TOMORROW_OPTIMIZATIONS.md trace notes outlining planned performance optimizations, guardrails, and status for this optimization round.

Tests:
- Extend buffer.worker tests to cover the new consolidated VAD summary semantics and inclusion of energy-based silence tail duration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Consolidated voice activity detection queries for improved reliability and reduced system overhead.
  * Added telemetry tracking to monitor cache performance per-prefix at configurable intervals.

* **Performance**
  * Batched multiple UI state updates to improve responsiveness during transcription finalization.
  * Optimized transcription display rendering in V4 mode to reduce unnecessary computation.

* **Bug Fixes**
  * Fixed lifecycle management in buffer visualizer to prevent operations after component unmount.
  * Enhanced cleanup of device pixel ratio listeners to prevent memory leaks.

* **Tests**
  * Added comprehensive tests for voice activity detection summarization and silence tail duration calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->