### PR TITLE
Performance: Optimize AudioEngine visualization loop

### DIFF
--- a/src/lib/audio/AudioEngine.ts
+++ b/src/lib/audio/AudioEngine.ts
@@ -1025,14 +1025,11 @@ export class AudioEngine implements IAudioEngine {
         }
         this.lastVisualizationNotifyTime = now;
 
-        // Ensure reuse buffer is ready (400 points * 2 min/max = 800 floats)
-        const targetWidth = 400;
-        const targetSize = targetWidth * 2;
-        if (!this.visualizationNotifyBuffer || this.visualizationNotifyBuffer.length !== targetSize) {
-            this.visualizationNotifyBuffer = new Float32Array(targetSize);
-        }
+        // Optimization: Skip computing visualization data (min/max resampling) as it is currently unused by the UI.
+        // App.tsx ignores the `data` argument and uses `getBarLevels()` (oscilloscope) instead.
+        // This avoids ~2000 loop iterations every 33ms (30fps) on the main thread.
+        const data = new Float32Array(0);
 
-        const data = this.getVisualizationData(targetWidth, this.visualizationNotifyBuffer); // 400 points is enough for modern displays and saves CPU
         const bufferEndTime = this.ringBuffer.getCurrentTime();
         this.visualizationCallbacks.forEach((cb) => cb(data, this.getMetrics(), bufferEndTime));
     }


### PR DESCRIPTION
**Performance Optimization**:
- **Target**: `AudioEngine.notifyVisualizationUpdate` (Main Thread Hot Path, ~30Hz).
- **Change**: Disabled the calculation of `visualizationData` (a 400-point min/max summary of the 30-second audio buffer).
- **Rationale**: Code analysis confirmed that the only active subscriber (`App.tsx`) ignores the `data` payload, utilizing `getBarLevels()` instead. The debug visualizer (`LayeredBufferVisualizer`) implements its own data fetching via `RingBuffer.readInto`.
- **Impact**: Removes ~2000 loop iterations and associated memory access per frame (33ms) on the main thread when the application is running.
- **Verification**: 
  - `pnpm test` passed (182 tests).
  - Manual verification of source code to ensure safety for existing consumers.
  - Note: `pnpm build` fails in the baseline environment due to a missing `tailwindcss` dev dependency, but this is unrelated to the `AudioEngine` changes.

---
*PR created automatically by Jules for task [16278444522442793407](https://jules.google.com/task/16278444522442793407) started by @ysdede*

## Summary by Sourcery

Enhancements:
- Stop generating min/max visualization data in AudioEngine.notifyVisualizationUpdate and pass an empty data payload since current UI consumers rely only on bar level metrics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized audio engine visualization processing to reduce main thread workload and improve application performance during audio playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->