### PR TITLE
fix(audio): return defensive copies from AudioSegmentProcessor stats

### DIFF
--- a/src/lib/audio/AudioSegmentProcessor.test.ts
+++ b/src/lib/audio/AudioSegmentProcessor.test.ts
@@ -66,4 +66,18 @@ describe('AudioSegmentProcessor', () => {
         expect(state.inSpeech).toBe(false);
         expect(state.speechStartTime).toBeNull();
     });
+
+    it('should return defensive copies from getStats', () => {
+        const processor = new AudioSegmentProcessor();
+        const stats = processor.getStats();
+
+        stats.noiseFloor = 999;
+        stats.speech.avgDuration = 123;
+        stats.silence.avgEnergy = 456;
+
+        const current = processor.getStats();
+        expect(current.noiseFloor).toBe(0.005);
+        expect(current.speech.avgDuration).toBe(0);
+        expect(current.silence.avgEnergy).toBe(0);
+    });
 });

--- a/src/lib/audio/AudioSegmentProcessor.ts
+++ b/src/lib/audio/AudioSegmentProcessor.ts
@@ -488,7 +488,12 @@ export class AudioSegmentProcessor {
      * Get current statistics.
      */
     getStats(): CurrentStats {
-        return this.state.currentStats;
+        const stats = this.state.currentStats;
+        return {
+            ...stats,
+            silence: { ...stats.silence },
+            speech: { ...stats.speech }
+        };
     }
 
     /**


### PR DESCRIPTION
Summary

* Make `getStats()` return defensive copies to prevent external mutation of internal state.
* Add a regression test for the defensive-copy behavior.

Verification

* `npm test -- src/lib/audio/AudioSegmentProcessor.test.ts`