### PR TITLE
chore: port additional safe stale-PR updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta http-equiv="Content-Security-Policy"
-    content="default-src 'self'; connect-src 'self' blob: https://huggingface.co https://*.huggingface.co https://*.hf.co https://fonts.googleapis.com https://fonts.gstatic.com; font-src 'self' https://fonts.gstatic.com; frame-src 'self'; img-src 'self' data:; object-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; worker-src 'self' blob:;" />
+    content="default-src 'self'; connect-src 'self' blob: https://huggingface.co https://*.huggingface.co https://*.hf.co; font-src 'self'; frame-src 'self'; img-src 'self' data:; object-src 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:;" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Keet - Privacy-first real-time transcription. Your audio stays on your device." />
   <meta name="theme-color" content="#6B705C" />
@@ -12,14 +12,6 @@
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <title>Keet - Real-time Transcription</title>
-
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link
-    href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,500;0,600;1,400&family=Plus+Jakarta+Sans:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
-    rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
-    rel="stylesheet" />
 
   <!-- PWA Manifest -->
   <link rel="manifest" href="./manifest.json" />

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@fontsource-variable/material-symbols-outlined": "^5.2.35",
+    "@fontsource/crimson-pro": "^5.2.8",
+    "@fontsource/jetbrains-mono": "^5.2.8",
+    "@fontsource/plus-jakarta-sans": "^5.2.8",
     "@tailwindcss/vite": "^4.1.18",
     "@vitest/web-worker": "^4.0.18",
     "cross-env": "^7.0.3",
@@ -24,10 +28,6 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
-    "@fontsource-variable/material-symbols-outlined": "^5.2.35",
-    "@fontsource/crimson-pro": "^5.2.8",
-    "@fontsource/jetbrains-mono": "^5.2.8",
-    "@fontsource/plus-jakarta-sans": "^5.2.8",
     "parakeet.js": "1.2.1",
     "solid-js": "^1.9.5",
     "wink-eng-lite-web-model": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
+    "@fontsource/crimson-pro": "^5.2.8",
+    "@fontsource/jetbrains-mono": "^5.2.8",
+    "@fontsource/material-symbols-outlined": "^5.2.35",
+    "@fontsource/plus-jakarta-sans": "^5.2.8",
     "parakeet.js": "1.2.1",
     "solid-js": "^1.9.5",
     "wink-eng-lite-web-model": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
+    "@fontsource-variable/material-symbols-outlined": "^5.2.35",
     "@fontsource/crimson-pro": "^5.2.8",
     "@fontsource/jetbrains-mono": "^5.2.8",
-    "@fontsource/material-symbols-outlined": "^5.2.35",
     "@fontsource/plus-jakarta-sans": "^5.2.8",
     "parakeet.js": "1.2.1",
     "solid-js": "^1.9.5",

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,500;0,600;1,400&family=Plus+Jakarta+Sans:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap');
 @import "tailwindcss";
 
 @theme {

--- a/src/index.css
+++ b/src/index.css
@@ -29,7 +29,7 @@
 
 /* Material Symbols - ensure they load and look sharp. */
 .material-symbols-outlined {
-  font-family: 'Material Symbols Outlined' !important;
+  font-family: 'Material Symbols Outlined Variable' !important;
   font-weight: normal;
   font-style: normal;
   font-size: 24px;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,7 +16,7 @@ import '@fontsource/plus-jakarta-sans/latin-500.css';
 import '@fontsource/plus-jakarta-sans/latin-600.css';
 import '@fontsource/jetbrains-mono/latin-400.css';
 import '@fontsource/jetbrains-mono/latin-500.css';
-import '@fontsource/material-symbols-outlined/latin-400.css';
+import '@fontsource-variable/material-symbols-outlined/fill.css';
 import App from './App';
 import './index.css';
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,17 @@
 
 /* @refresh reload */
 import { render } from 'solid-js/web';
+import '@fontsource/crimson-pro/latin-400.css';
+import '@fontsource/crimson-pro/latin-500.css';
+import '@fontsource/crimson-pro/latin-600.css';
+import '@fontsource/crimson-pro/latin-400-italic.css';
+import '@fontsource/plus-jakarta-sans/latin-300.css';
+import '@fontsource/plus-jakarta-sans/latin-400.css';
+import '@fontsource/plus-jakarta-sans/latin-500.css';
+import '@fontsource/plus-jakarta-sans/latin-600.css';
+import '@fontsource/jetbrains-mono/latin-400.css';
+import '@fontsource/jetbrains-mono/latin-500.css';
+import '@fontsource/material-symbols-outlined/latin-400.css';
 import App from './App';
 import './index.css';
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,7 +16,7 @@ import '@fontsource/plus-jakarta-sans/latin-500.css';
 import '@fontsource/plus-jakarta-sans/latin-600.css';
 import '@fontsource/jetbrains-mono/latin-400.css';
 import '@fontsource/jetbrains-mono/latin-500.css';
-import '@fontsource-variable/material-symbols-outlined/fill.css';
+import '@fontsource-variable/material-symbols-outlined';
 import App from './App';
 import './index.css';
 

--- a/src/lib/audio/AudioSegmentProcessor.test.ts
+++ b/src/lib/audio/AudioSegmentProcessor.test.ts
@@ -104,8 +104,9 @@ describe('AudioSegmentProcessor', () => {
         expect(emittedSegments.length).toBeGreaterThan(0);
 
         const firstSegment = emittedSegments[0];
-        expect(firstSegment.duration).toBeGreaterThanOrEqual(maxDuration);
-        expect(firstSegment.duration).toBeLessThan(maxDuration + 0.2);
+        const splitTolerance = 0.15;
+        // Duration is quantized by chunk boundaries; assert near maxDuration with tolerance.
+        expect(Math.abs(firstSegment.duration - maxDuration)).toBeLessThanOrEqual(splitTolerance);
 
         const finalState = processor.getStateInfo();
         expect(finalState.inSpeech).toBe(true);

--- a/src/lib/audio/AudioSegmentProcessor.test.ts
+++ b/src/lib/audio/AudioSegmentProcessor.test.ts
@@ -77,7 +77,8 @@ describe('AudioSegmentProcessor', () => {
             energyThreshold: 0.01,
             minSpeechDuration: 0.1,
             snrThreshold: 0,
-            minSnrThreshold: 0
+            minSnrThreshold: 0,
+            logger: () => {}
         });
 
         const chunkSize = Math.round(sampleRate * 0.1);
@@ -104,7 +105,7 @@ describe('AudioSegmentProcessor', () => {
         expect(emittedSegments.length).toBeGreaterThan(0);
 
         const firstSegment = emittedSegments[0];
-        const splitTolerance = 0.15;
+        const splitTolerance = 0.1;
         // Duration is quantized by chunk boundaries; assert near maxDuration with tolerance.
         expect(Math.abs(firstSegment.duration - maxDuration)).toBeLessThanOrEqual(splitTolerance);
 

--- a/src/lib/audio/AudioSegmentProcessor.ts
+++ b/src/lib/audio/AudioSegmentProcessor.ts
@@ -269,7 +269,6 @@ export class AudioSegmentProcessor {
 
                     if (this.state.speechStats.length > this.options.maxHistoryLength) {
                         this.state.speechStats.shift();
-                        this.state.cachedSpeechSummary = null;
                     }
                 }
 

--- a/src/lib/audio/AudioSegmentProcessor.ts
+++ b/src/lib/audio/AudioSegmentProcessor.ts
@@ -58,6 +58,7 @@ interface ProcessorState {
     silenceEnergies: number[];
     speechStats: SegmentStats[];
     silenceStats: SegmentStats[];
+    cachedSpeechSummary: StatsSummary | null;
     currentStats: CurrentStats;
     noiseFloor: number;
     recentEnergies: number[];
@@ -264,9 +265,11 @@ export class AudioSegmentProcessor {
                         avgEnergy,
                         energyIntegral: avgEnergy * speechDuration
                     });
+                    this.state.cachedSpeechSummary = null;
 
                     if (this.state.speechStats.length > this.options.maxHistoryLength) {
                         this.state.speechStats.shift();
+                        this.state.cachedSpeechSummary = null;
                     }
                 }
 
@@ -467,12 +470,15 @@ export class AudioSegmentProcessor {
             };
         }
 
-        if (this.state.speechStats.length > 0) {
+        if (this.state.cachedSpeechSummary) {
+            stats.speech = this.state.cachedSpeechSummary;
+        } else if (this.state.speechStats.length > 0) {
             stats.speech = {
                 avgDuration: this.average(this.state.speechStats.map(s => s.duration)),
                 avgEnergy: this.average(this.state.speechStats.map(s => s.avgEnergy)),
                 avgEnergyIntegral: this.average(this.state.speechStats.map(s => s.energyIntegral))
             };
+            this.state.cachedSpeechSummary = stats.speech;
         }
 
         this.state.currentStats = stats;
@@ -521,6 +527,7 @@ export class AudioSegmentProcessor {
             silenceEnergies: [],
             speechStats: [],
             silenceStats: [],
+            cachedSpeechSummary: null,
             currentStats: {
                 silence: { avgDuration: 0, avgEnergy: 0, avgEnergyIntegral: 0 },
                 speech: { avgDuration: 0, avgEnergy: 0, avgEnergyIntegral: 0 },


### PR DESCRIPTION
Summary
Ports additional low-risk, still-valid work from stale open PRs onto current `master`.

### Ported from stale PRs
- #164: cache computed speech summary in `AudioSegmentProcessor` to avoid repeated hot-path array/reduce work in `updateStats`.
- #66: add proactive long-segment split test coverage in `AudioSegmentProcessor.test.ts`.
- #70 (adapted to current typography): self-host app fonts and remove Google Fonts CDN usage.

Details
- `src/lib/audio/AudioSegmentProcessor.ts`
  - Adds `cachedSpeechSummary` state cache.
  - Invalidates cache only when speech stats history changes.
- `src/lib/audio/AudioSegmentProcessor.test.ts`
  - Adds test for proactive split behavior when segment exceeds `maxSegmentDuration`.
- `index.html`, `src/index.css`, `src/index.tsx`, `package.json`
  - Remove external Google Fonts links/imports.
  - Import local `@fontsource/*` packages for existing fonts.
  - Tighten CSP by dropping `fonts.googleapis.com` and `fonts.gstatic.com` allowances.

Validation
- `npm test -- src/lib/audio/AudioSegmentProcessor.test.ts` 
- `npm run build` 

Scope boundaries
- No changes to fragile transcription window/cursor/finalization logic.