### PR TITLE
test: port safe AudioSegmentProcessor coverage from stale PR

### DIFF
--- a/src/lib/audio/AudioSegmentProcessor.test.ts
+++ b/src/lib/audio/AudioSegmentProcessor.test.ts
@@ -4,7 +4,7 @@ import { AudioSegmentProcessor } from './AudioSegmentProcessor';
 
 describe('AudioSegmentProcessor', () => {
     it('should initialize without errors', () => {
-        const processor = new AudioSegmentProcessor();
+        const processor = new AudioSegmentProcessor({ logger: () => { } });
         expect(processor).toBeDefined();
         const stats = processor.getStats();
         expect(stats).toBeDefined();
@@ -14,7 +14,8 @@ describe('AudioSegmentProcessor', () => {
     it('should process silence without detecting segments', () => {
         const processor = new AudioSegmentProcessor({
             sampleRate: 16000,
-            energyThreshold: 0.1
+            energyThreshold: 0.1,
+            logger: () => { },
         });
 
         // 16000 samples = 1 second
@@ -34,7 +35,8 @@ describe('AudioSegmentProcessor', () => {
         // Real VAD is complex, so we just check state transitions if we force high energy
         const processor = new AudioSegmentProcessor({
             sampleRate: 16000,
-            energyThreshold: 0.01
+            energyThreshold: 0.01,
+            logger: () => { },
         });
 
         const speech = new Float32Array(1600).fill(0.5); // 100ms
@@ -52,7 +54,7 @@ describe('AudioSegmentProcessor', () => {
     });
 
     it('should reset state correctly', () => {
-        const processor = new AudioSegmentProcessor();
+        const processor = new AudioSegmentProcessor({ logger: () => { } });
 
         // Simulate some state change
         const chunk = new Float32Array(100).fill(0.1);
@@ -67,8 +69,83 @@ describe('AudioSegmentProcessor', () => {
         expect(state.speechStartTime).toBeNull();
     });
 
+    it('should adapt noise floor during sustained silence', () => {
+        const processor = new AudioSegmentProcessor({
+            sampleRate: 16000,
+            logger: () => { },
+        });
+        const silenceChunk = new Float32Array(1280).fill(0);
+
+        for (let i = 0; i < 20; i++) {
+            processor.processAudioData(silenceChunk, (i + 1) * 0.08, 0.0001);
+        }
+
+        const state = processor.getStateInfo();
+        expect(state.noiseFloor).toBeLessThan(0.005);
+        expect(state.noiseFloor).toBeGreaterThan(0);
+    });
+
+    it('should end speech after configured silence threshold', () => {
+        const processor = new AudioSegmentProcessor({
+            sampleRate: 16000,
+            energyThreshold: 0.01,
+            silenceThreshold: 0.16,
+            logger: () => { },
+        });
+        const speechChunk = new Float32Array(1280).fill(0.5);
+        const silenceChunk = new Float32Array(1280).fill(0);
+
+        processor.processAudioData(speechChunk, 0.0, 0.5);
+        processor.processAudioData(speechChunk, 0.08, 0.5);
+
+        const firstSilence = processor.processAudioData(silenceChunk, 0.16, 0.0001);
+        expect(firstSilence.length).toBe(0);
+        expect(processor.getStateInfo().inSpeech).toBe(true);
+
+        const secondSilence = processor.processAudioData(silenceChunk, 0.24, 0.0001);
+        expect(secondSilence.length).toBe(1);
+        expect(secondSilence[0].duration).toBeGreaterThan(0);
+        expect(processor.getStateInfo().inSpeech).toBe(false);
+    });
+
+    it('should update speech detection behavior when threshold changes', () => {
+        const processor = new AudioSegmentProcessor({
+            sampleRate: 16000,
+            logger: () => { },
+        });
+        const speechChunk = new Float32Array(1280).fill(0.5);
+
+        processor.setThreshold(0.9);
+        processor.reset();
+        processor.processAudioData(speechChunk, 0.08, 0.5);
+        expect(processor.getStateInfo().inSpeech).toBe(false);
+
+        processor.setThreshold(0.1);
+        processor.processAudioData(speechChunk, 0.16, 0.5);
+        expect(processor.getStateInfo().inSpeech).toBe(true);
+    });
+
+    it('should update speech statistics after a completed segment', () => {
+        const processor = new AudioSegmentProcessor({
+            sampleRate: 16000,
+            energyThreshold: 0.01,
+            silenceThreshold: 0.08,
+            maxSilenceWithinSpeech: 0,
+            logger: () => { },
+        });
+        const speechChunk = new Float32Array(1280).fill(0.5);
+        const silenceChunk = new Float32Array(1280).fill(0);
+
+        processor.processAudioData(speechChunk, 0.0, 0.5);
+        processor.processAudioData(silenceChunk, 0.08, 0.0001);
+
+        const stats = processor.getStats();
+        expect(stats.speech.avgDuration).toBeGreaterThan(0);
+        expect(stats.speech.avgEnergy).toBeGreaterThan(0);
+    });
+
     it('should return defensive copies from getStats', () => {
-        const processor = new AudioSegmentProcessor();
+        const processor = new AudioSegmentProcessor({ logger: () => { } });
         const stats = processor.getStats();
 
         stats.noiseFloor = 999;

--- a/src/lib/audio/AudioSegmentProcessor.test.ts
+++ b/src/lib/audio/AudioSegmentProcessor.test.ts
@@ -1,10 +1,24 @@
 
 import { describe, it, expect } from 'vitest';
-import { AudioSegmentProcessor } from './AudioSegmentProcessor';
+import { AudioSegmentProcessor, type AudioSegmentProcessorConfig } from './AudioSegmentProcessor';
+
+const SAMPLE_RATE = 16000;
+const CHUNK_DURATION_SEC = 0.08;
+const CHUNK_SIZE = Math.round(SAMPLE_RATE * CHUNK_DURATION_SEC);
+const SPEECH_ENERGY = 0.5;
+const SILENCE_ENERGY = 0.0001;
+const noopLogger = () => { };
+
+const createProcessor = (overrides: Partial<AudioSegmentProcessorConfig> = {}) =>
+    new AudioSegmentProcessor({
+        sampleRate: SAMPLE_RATE,
+        logger: noopLogger,
+        ...overrides,
+    });
 
 describe('AudioSegmentProcessor', () => {
     it('should initialize without errors', () => {
-        const processor = new AudioSegmentProcessor({ logger: () => { } });
+        const processor = createProcessor();
         expect(processor).toBeDefined();
         const stats = processor.getStats();
         expect(stats).toBeDefined();
@@ -12,15 +26,11 @@ describe('AudioSegmentProcessor', () => {
     });
 
     it('should process silence without detecting segments', () => {
-        const processor = new AudioSegmentProcessor({
-            sampleRate: 16000,
-            energyThreshold: 0.1,
-            logger: () => { },
-        });
+        const processor = createProcessor({ energyThreshold: 0.1 });
 
-        // 16000 samples = 1 second
-        const silence = new Float32Array(16000).fill(0);
-        const energy = 0.0001;
+        // 1 second of silence at 16kHz
+        const silence = new Float32Array(SAMPLE_RATE).fill(0);
+        const energy = SILENCE_ENERGY;
         const currentTime = 1.0;
 
         const segments = processor.processAudioData(silence, currentTime, energy);
@@ -33,14 +43,10 @@ describe('AudioSegmentProcessor', () => {
     it('should process speech and detect segments', () => {
         // This is a simplified test.
         // Real VAD is complex, so we just check state transitions if we force high energy
-        const processor = new AudioSegmentProcessor({
-            sampleRate: 16000,
-            energyThreshold: 0.01,
-            logger: () => { },
-        });
+        const processor = createProcessor({ energyThreshold: 0.01 });
 
-        const speech = new Float32Array(1600).fill(0.5); // 100ms
-        const energy = 0.5; // High energy
+        const speech = new Float32Array(Math.round(SAMPLE_RATE * 0.1)).fill(SPEECH_ENERGY);
+        const energy = SPEECH_ENERGY;
 
         // Process a few chunks to trigger speech detection
         let segments = processor.processAudioData(speech, 1.0, energy);
@@ -54,7 +60,7 @@ describe('AudioSegmentProcessor', () => {
     });
 
     it('should reset state correctly', () => {
-        const processor = new AudioSegmentProcessor({ logger: () => { } });
+        const processor = createProcessor();
 
         // Simulate some state change
         const chunk = new Float32Array(100).fill(0.1);
@@ -70,14 +76,11 @@ describe('AudioSegmentProcessor', () => {
     });
 
     it('should adapt noise floor during sustained silence', () => {
-        const processor = new AudioSegmentProcessor({
-            sampleRate: 16000,
-            logger: () => { },
-        });
-        const silenceChunk = new Float32Array(1280).fill(0);
+        const processor = createProcessor();
+        const silenceChunk = new Float32Array(CHUNK_SIZE).fill(0);
 
         for (let i = 0; i < 20; i++) {
-            processor.processAudioData(silenceChunk, (i + 1) * 0.08, 0.0001);
+            processor.processAudioData(silenceChunk, (i + 1) * CHUNK_DURATION_SEC, SILENCE_ENERGY);
         }
 
         const state = processor.getStateInfo();
@@ -86,58 +89,60 @@ describe('AudioSegmentProcessor', () => {
     });
 
     it('should end speech after configured silence threshold', () => {
-        const processor = new AudioSegmentProcessor({
-            sampleRate: 16000,
+        const silenceThresholdSec = 0.16;
+        const processor = createProcessor({
             energyThreshold: 0.01,
-            silenceThreshold: 0.16,
-            logger: () => { },
+            silenceThreshold: silenceThresholdSec,
         });
-        const speechChunk = new Float32Array(1280).fill(0.5);
-        const silenceChunk = new Float32Array(1280).fill(0);
+        const speechChunk = new Float32Array(CHUNK_SIZE).fill(SPEECH_ENERGY);
+        const silenceChunk = new Float32Array(CHUNK_SIZE).fill(0);
 
-        processor.processAudioData(speechChunk, 0.0, 0.5);
-        processor.processAudioData(speechChunk, 0.08, 0.5);
+        processor.processAudioData(speechChunk, 0.0, SPEECH_ENERGY);
+        processor.processAudioData(speechChunk, CHUNK_DURATION_SEC, SPEECH_ENERGY);
 
-        const firstSilence = processor.processAudioData(silenceChunk, 0.16, 0.0001);
+        const firstSilence = processor.processAudioData(
+            silenceChunk,
+            2 * CHUNK_DURATION_SEC,
+            SILENCE_ENERGY,
+        );
         expect(firstSilence.length).toBe(0);
         expect(processor.getStateInfo().inSpeech).toBe(true);
 
-        const secondSilence = processor.processAudioData(silenceChunk, 0.24, 0.0001);
+        const secondSilence = processor.processAudioData(
+            silenceChunk,
+            3 * CHUNK_DURATION_SEC,
+            SILENCE_ENERGY,
+        );
         expect(secondSilence.length).toBe(1);
         expect(secondSilence[0].duration).toBeGreaterThan(0);
         expect(processor.getStateInfo().inSpeech).toBe(false);
     });
 
     it('should update speech detection behavior when threshold changes', () => {
-        const processor = new AudioSegmentProcessor({
-            sampleRate: 16000,
-            logger: () => { },
-        });
-        const speechChunk = new Float32Array(1280).fill(0.5);
+        const processor = createProcessor();
+        const speechChunk = new Float32Array(CHUNK_SIZE).fill(SPEECH_ENERGY);
 
         processor.setThreshold(0.9);
         processor.reset();
-        processor.processAudioData(speechChunk, 0.08, 0.5);
+        processor.processAudioData(speechChunk, CHUNK_DURATION_SEC, SPEECH_ENERGY);
         expect(processor.getStateInfo().inSpeech).toBe(false);
 
         processor.setThreshold(0.1);
-        processor.processAudioData(speechChunk, 0.16, 0.5);
+        processor.processAudioData(speechChunk, 2 * CHUNK_DURATION_SEC, SPEECH_ENERGY);
         expect(processor.getStateInfo().inSpeech).toBe(true);
     });
 
     it('should update speech statistics after a completed segment', () => {
-        const processor = new AudioSegmentProcessor({
-            sampleRate: 16000,
+        const processor = createProcessor({
             energyThreshold: 0.01,
-            silenceThreshold: 0.08,
+            silenceThreshold: CHUNK_DURATION_SEC,
             maxSilenceWithinSpeech: 0,
-            logger: () => { },
         });
-        const speechChunk = new Float32Array(1280).fill(0.5);
-        const silenceChunk = new Float32Array(1280).fill(0);
+        const speechChunk = new Float32Array(CHUNK_SIZE).fill(SPEECH_ENERGY);
+        const silenceChunk = new Float32Array(CHUNK_SIZE).fill(0);
 
-        processor.processAudioData(speechChunk, 0.0, 0.5);
-        processor.processAudioData(silenceChunk, 0.08, 0.0001);
+        processor.processAudioData(speechChunk, 0.0, SPEECH_ENERGY);
+        processor.processAudioData(silenceChunk, CHUNK_DURATION_SEC, SILENCE_ENERGY);
 
         const stats = processor.getStats();
         expect(stats.speech.avgDuration).toBeGreaterThan(0);
@@ -145,7 +150,7 @@ describe('AudioSegmentProcessor', () => {
     });
 
     it('should return defensive copies from getStats', () => {
-        const processor = new AudioSegmentProcessor({ logger: () => { } });
+        const processor = createProcessor();
         const stats = processor.getStats();
 
         stats.noiseFloor = 999;

--- a/src/lib/transcription/TokenStreamTranscriber.test.ts
+++ b/src/lib/transcription/TokenStreamTranscriber.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TokenStreamTranscriber } from './TokenStreamTranscriber';
+import { ModelManager } from './ModelManager';
+
+const mockMergerInstance = {
+    processChunk: vi.fn(),
+    getText: vi.fn(),
+    reset: vi.fn(),
+    getState: vi.fn(),
+};
+
+vi.mock('parakeet.js', () => ({
+    LCSPTFAMerger: class {
+        constructor() {
+            return mockMergerInstance;
+        }
+    },
+}));
+
+const mockModel = {
+    transcribe: vi.fn(),
+    tokenizer: {},
+    getFrameTimeStride: vi.fn(() => 0.08),
+};
+
+const mockModelManager = {
+    getModel: vi.fn(() => mockModel),
+} as unknown as ModelManager;
+
+describe('TokenStreamTranscriber', () => {
+    let transcriber: TokenStreamTranscriber;
+    let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
+
+        mockMergerInstance.processChunk.mockReturnValue({
+            lcsLength: 5,
+            anchorValid: true,
+            anchorTokens: ['a', 'b'],
+            confirmed: [],
+            pending: [],
+        });
+        mockMergerInstance.getText.mockReturnValue({
+            confirmed: 'Hello',
+            pending: ' world',
+            full: 'Hello world',
+        });
+        mockModel.transcribe.mockResolvedValue({
+            metrics: { total_ms: 100 },
+        });
+
+        transcriber = new TokenStreamTranscriber(mockModelManager);
+    });
+
+    afterEach(() => {
+        consoleLogSpy.mockRestore();
+    });
+
+    it('processChunk should call model.transcribe and merger.processChunk', async () => {
+        await transcriber.initialize();
+
+        const audio = new Float32Array(16000 * 2);
+        const result = await transcriber.processChunk(audio, 0);
+
+        expect(mockModel.transcribe).toHaveBeenCalled();
+        expect(mockMergerInstance.processChunk).toHaveBeenCalled();
+        expect(result.fullText).toBe('Hello world');
+        expect(result.chunkCount).toBe(1);
+    });
+
+    it('processChunkWithFeatures should call model.transcribe and merger.processChunk', async () => {
+        await transcriber.initialize();
+
+        const features = new Float32Array(80 * 100);
+        const result = await transcriber.processChunkWithFeatures(features, 100, 80, 0, 0);
+
+        expect(mockModel.transcribe).toHaveBeenCalledWith(
+            null,
+            expect.any(Number),
+            expect.objectContaining({
+                precomputedFeatures: expect.objectContaining({ features }),
+            }),
+        );
+        expect(mockMergerInstance.processChunk).toHaveBeenCalled();
+        expect(result.fullText).toBe('Hello world');
+        expect(result.chunkCount).toBe(1);
+    });
+});


### PR DESCRIPTION
Summary
Ports only low-risk test coverage from stale PRs onto current `master`.

What changed
- `src/lib/audio/AudioSegmentProcessor.test.ts`
  - Added deterministic tests for:
    - noise floor adaptation during sustained silence
    - speech end detection after configured silence threshold
    - runtime threshold updates via `setThreshold`
    - speech statistics update after completed segment
  - Silenced test logger output to keep CI logs readable.
- `src/lib/transcription/TokenStreamTranscriber.test.ts` (new)
  - Added unit tests verifying both audio-path and feature-path processing call model transcription and merger hooks correctly.
  - Mocked `parakeet.js` merger and silenced console logs in test scope.

Why this is safe
- Test-only change; no runtime logic changes.
- Avoids fragile window/cursor/finalization code paths.

Validation
- `npm test -- src/lib/transcription/TokenStreamTranscriber.test.ts src/lib/audio/AudioSegmentProcessor.test.ts` 
- `npm run build` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Summary by CodeRabbit

* **Tests**
  * Expanded audio segment processor tests with improved setup patterns and additional validation scenarios for noise floor adaptation, speech detection, and statistics handling.
  * Added comprehensive test suite for token stream transcriber covering initialization and chunk processing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->