### PR TITLE
feat: persist and restore UI/audio/model settings

### DIFF
--- a/src/stores/appStore.test.ts
+++ b/src/stores/appStore.test.ts
@@ -94,6 +94,56 @@ describe('appStore', () => {
       expect(store.selectedDeviceId()).toBe('mic1');
     });
 
+    it('should keep selected device when it still exists', async () => {
+      const mockDevices = [
+        { kind: 'audioinput', deviceId: 'mic1', label: 'Microphone 1' },
+        { kind: 'audioinput', deviceId: 'mic2', label: 'Microphone 2' },
+      ];
+      const enumerateDevicesMock = vi.fn().mockResolvedValue(mockDevices);
+
+      if (!navigator.mediaDevices) {
+        Object.defineProperty(navigator, 'mediaDevices', {
+          value: {},
+          writable: true
+        });
+      }
+
+      Object.defineProperty(navigator.mediaDevices, 'enumerateDevices', {
+        value: enumerateDevicesMock,
+        writable: true
+      });
+
+      store.setSelectedDeviceId('mic2');
+      await store.refreshDevices();
+
+      expect(store.selectedDeviceId()).toBe('mic2');
+    });
+
+    it('should fall back to first device when selected device is unavailable', async () => {
+      const mockDevices = [
+        { kind: 'audioinput', deviceId: 'mic1', label: 'Microphone 1' },
+        { kind: 'audioinput', deviceId: 'mic2', label: 'Microphone 2' },
+      ];
+      const enumerateDevicesMock = vi.fn().mockResolvedValue(mockDevices);
+
+      if (!navigator.mediaDevices) {
+        Object.defineProperty(navigator, 'mediaDevices', {
+          value: {},
+          writable: true
+        });
+      }
+
+      Object.defineProperty(navigator.mediaDevices, 'enumerateDevices', {
+        value: enumerateDevicesMock,
+        writable: true
+      });
+
+      store.setSelectedDeviceId('missing-device');
+      await store.refreshDevices();
+
+      expect(store.selectedDeviceId()).toBe('mic1');
+    });
+
     it('should handle errors when refreshing devices', async () => {
        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
        const enumerateDevicesMock = vi.fn().mockRejectedValue(new Error('Permission denied'));

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -252,7 +252,7 @@ export function createAppStore() {
           const label = device.label.trim().toLowerCase();
           if (!label) return false;
           if (label === preferredDeviceLabel) return true;
-          return label.includes(preferredDeviceLabel) || preferredDeviceLabel.includes(label);
+          return label.includes(preferredDeviceLabel);
         });
         if (preferredByLabel) {
           setSelectedDeviceId(preferredByLabel.deviceId);

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -218,10 +218,26 @@ export function createAppStore() {
 
   const refreshDevices = async () => {
     try {
+      if (typeof navigator === 'undefined' || !navigator.mediaDevices?.enumerateDevices) {
+        setAvailableDevices([]);
+        setSelectedDeviceId('');
+        return;
+      }
+
       const devices = await navigator.mediaDevices.enumerateDevices();
       const mics = devices.filter(d => d.kind === 'audioinput');
       setAvailableDevices(mics);
-      if (mics.length > 0 && !selectedDeviceId()) {
+
+      if (mics.length === 0) {
+        setSelectedDeviceId('');
+        return;
+      }
+
+      const currentSelectedId = selectedDeviceId();
+      const hasCurrentSelection =
+        currentSelectedId.length > 0 && mics.some((device) => device.deviceId === currentSelectedId);
+
+      if (!hasCurrentSelection) {
         setSelectedDeviceId(mics[0].deviceId);
       }
     } catch (e) {

--- a/src/utils/settingsStorage.test.ts
+++ b/src/utils/settingsStorage.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  APP_SETTINGS_STORAGE_KEY,
+  loadSettingsFromStorage,
+  saveSettingsToStorage,
+} from './settingsStorage';
+
+describe('settingsStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns empty settings for invalid JSON', () => {
+    localStorage.setItem(APP_SETTINGS_STORAGE_KEY, '{not-json');
+    expect(loadSettingsFromStorage()).toEqual({});
+  });
+
+  it('loads and clamps only known fields', () => {
+    localStorage.setItem(APP_SETTINGS_STORAGE_KEY, JSON.stringify({
+      general: {
+        energyThreshold: 99,
+        sileroThreshold: -1,
+        v4InferenceIntervalMs: 9000,
+        v4SilenceFlushSec: -4,
+        streamingWindow: 1.2,
+      },
+      model: { selectedModelId: 'parakeet-tdt-0.6b-v2' },
+      audio: { selectedDeviceId: 'device-1', selectedDeviceLabel: 'Mic 1' },
+      ui: {
+        widgetPosition: { x: 12, y: 18 },
+        debugPanel: { visible: true, height: 9999 },
+        transcript: { activeTab: 'merged', mergedSplitRatio: 0.1 },
+      },
+      unexpected: { ignored: true },
+    }));
+
+    const loaded = loadSettingsFromStorage();
+    expect(loaded.general?.energyThreshold).toBe(0.3);
+    expect(loaded.general?.sileroThreshold).toBe(0.1);
+    expect(loaded.general?.v4InferenceIntervalMs).toBe(8000);
+    expect(loaded.general?.v4SilenceFlushSec).toBe(0.3);
+    expect(loaded.general?.streamingWindow).toBe(2);
+    expect(loaded.model?.selectedModelId).toBe('parakeet-tdt-0.6b-v2');
+    expect(loaded.audio?.selectedDeviceId).toBe('device-1');
+    expect(loaded.ui?.widgetPosition).toEqual({ x: 12, y: 18 });
+    expect(loaded.ui?.debugPanel?.visible).toBe(true);
+    expect(loaded.ui?.debugPanel?.height).toBe(520);
+    expect(loaded.ui?.transcript?.activeTab).toBe('merged');
+    expect(loaded.ui?.transcript?.mergedSplitRatio).toBe(0.3);
+  });
+
+  it('uses legacy keys when unified key has no matching fields', () => {
+    localStorage.setItem('boncukjs-control-widget-pos', JSON.stringify({ x: 40, y: 80 }));
+    localStorage.setItem('keet-merged-split-ratio', '0.62');
+
+    const loaded = loadSettingsFromStorage();
+    expect(loaded.ui?.widgetPosition).toEqual({ x: 40, y: 80 });
+    expect(loaded.ui?.transcript?.mergedSplitRatio).toBe(0.62);
+  });
+
+  it('saves settings payload under stable key', () => {
+    saveSettingsToStorage({
+      model: { selectedModelId: 'parakeet-tdt-0.6b-v2' },
+      ui: { transcript: { activeTab: 'live', mergedSplitRatio: 0.5 } },
+    });
+
+    const raw = localStorage.getItem(APP_SETTINGS_STORAGE_KEY);
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw as string)).toMatchObject({
+      model: { selectedModelId: 'parakeet-tdt-0.6b-v2' },
+      ui: { transcript: { activeTab: 'live', mergedSplitRatio: 0.5 } },
+    });
+  });
+});

--- a/src/utils/settingsStorage.ts
+++ b/src/utils/settingsStorage.ts
@@ -1,0 +1,236 @@
+export const APP_SETTINGS_STORAGE_KEY = 'keet-app-settings';
+const LEGACY_WIDGET_POSITION_STORAGE_KEY = 'boncukjs-control-widget-pos';
+const LEGACY_MERGED_SPLIT_STORAGE_KEY = 'keet-merged-split-ratio';
+
+export const MIN_DEBUG_PANEL_HEIGHT = 120;
+export const MAX_DEBUG_PANEL_HEIGHT = 520;
+export const DEFAULT_DEBUG_PANEL_HEIGHT = 220;
+
+export const MIN_MERGED_SPLIT_RATIO = 0.3;
+export const MAX_MERGED_SPLIT_RATIO = 0.7;
+export const DEFAULT_MERGED_SPLIT_RATIO = 0.5;
+
+export type StoredTranscriptTab = 'live' | 'merged';
+
+export interface PersistedSettings {
+  general?: {
+    energyThreshold?: number;
+    sileroThreshold?: number;
+    v4InferenceIntervalMs?: number;
+    v4SilenceFlushSec?: number;
+    streamingWindow?: number;
+  };
+  model?: {
+    selectedModelId?: string;
+  };
+  audio?: {
+    selectedDeviceId?: string;
+    selectedDeviceLabel?: string;
+  };
+  ui?: {
+    widgetPosition?: {
+      x: number;
+      y: number;
+    };
+    debugPanel?: {
+      visible?: boolean;
+      height?: number;
+    };
+    transcript?: {
+      activeTab?: StoredTranscriptTab;
+      mergedSplitRatio?: number;
+    };
+  };
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+const readFiniteNumber = (value: unknown): number | undefined => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;
+  return value;
+};
+
+const readNumberInRange = (value: unknown, min: number, max: number): number | undefined => {
+  const numeric = readFiniteNumber(value);
+  if (numeric === undefined) return undefined;
+  return clamp(numeric, min, max);
+};
+
+const readIntegerInRange = (value: unknown, min: number, max: number): number | undefined => {
+  const numeric = readFiniteNumber(value);
+  if (numeric === undefined) return undefined;
+  return Math.round(clamp(numeric, min, max));
+};
+
+const readString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const readBoolean = (value: unknown): boolean | undefined => {
+  if (typeof value !== 'boolean') return undefined;
+  return value;
+};
+
+export const clampDebugPanelHeight = (height: number): number =>
+  clamp(height, MIN_DEBUG_PANEL_HEIGHT, MAX_DEBUG_PANEL_HEIGHT);
+
+export const clampMergedSplitRatio = (ratio: number): number =>
+  clamp(ratio, MIN_MERGED_SPLIT_RATIO, MAX_MERGED_SPLIT_RATIO);
+
+const readWidgetPosition = (value: unknown): { x: number; y: number } | undefined => {
+  if (!isRecord(value)) return undefined;
+  const x = readFiniteNumber(value.x);
+  const y = readFiniteNumber(value.y);
+  if (x === undefined || y === undefined) return undefined;
+  return { x, y };
+};
+
+const readTranscriptTab = (value: unknown): StoredTranscriptTab | undefined => {
+  if (value === 'live' || value === 'merged') return value;
+  return undefined;
+};
+
+const sanitizeSettings = (value: unknown): PersistedSettings => {
+  if (!isRecord(value)) return {};
+
+  const settings: PersistedSettings = {};
+
+  const general = isRecord(value.general) ? value.general : null;
+  if (general) {
+    const nextGeneral: PersistedSettings['general'] = {};
+    nextGeneral.energyThreshold = readNumberInRange(general.energyThreshold, 0.005, 0.3);
+    nextGeneral.sileroThreshold = readNumberInRange(general.sileroThreshold, 0.1, 0.9);
+    nextGeneral.v4InferenceIntervalMs = readIntegerInRange(general.v4InferenceIntervalMs, 160, 8000);
+    nextGeneral.v4SilenceFlushSec = readNumberInRange(general.v4SilenceFlushSec, 0.3, 5.0);
+    nextGeneral.streamingWindow = readNumberInRange(general.streamingWindow, 2.0, 15.0);
+    if (Object.values(nextGeneral).some((v) => v !== undefined)) {
+      settings.general = nextGeneral;
+    }
+  }
+
+  const model = isRecord(value.model) ? value.model : null;
+  if (model) {
+    const selectedModelId = readString(model.selectedModelId);
+    if (selectedModelId) {
+      settings.model = { selectedModelId };
+    }
+  }
+
+  const audio = isRecord(value.audio) ? value.audio : null;
+  if (audio) {
+    const selectedDeviceId = readString(audio.selectedDeviceId);
+    const selectedDeviceLabel = readString(audio.selectedDeviceLabel);
+    if (selectedDeviceId || selectedDeviceLabel) {
+      settings.audio = {};
+      if (selectedDeviceId) settings.audio.selectedDeviceId = selectedDeviceId;
+      if (selectedDeviceLabel) settings.audio.selectedDeviceLabel = selectedDeviceLabel;
+    }
+  }
+
+  const ui = isRecord(value.ui) ? value.ui : null;
+  if (ui) {
+    const nextUi: PersistedSettings['ui'] = {};
+
+    const widgetPosition = readWidgetPosition(ui.widgetPosition);
+    if (widgetPosition) nextUi.widgetPosition = widgetPosition;
+
+    const debugPanel = isRecord(ui.debugPanel) ? ui.debugPanel : null;
+    if (debugPanel) {
+      const visible = readBoolean(debugPanel.visible);
+      const heightValue = readFiniteNumber(debugPanel.height);
+      const height = heightValue === undefined ? undefined : clampDebugPanelHeight(heightValue);
+      if (visible !== undefined || height !== undefined) {
+        nextUi.debugPanel = {};
+        if (visible !== undefined) nextUi.debugPanel.visible = visible;
+        if (height !== undefined) nextUi.debugPanel.height = height;
+      }
+    }
+
+    const transcript = isRecord(ui.transcript) ? ui.transcript : null;
+    if (transcript) {
+      const activeTab = readTranscriptTab(transcript.activeTab);
+      const mergedSplitValue = readFiniteNumber(transcript.mergedSplitRatio);
+      const mergedSplitRatio =
+        mergedSplitValue === undefined ? undefined : clampMergedSplitRatio(mergedSplitValue);
+      if (activeTab || mergedSplitRatio !== undefined) {
+        nextUi.transcript = {};
+        if (activeTab) nextUi.transcript.activeTab = activeTab;
+        if (mergedSplitRatio !== undefined) nextUi.transcript.mergedSplitRatio = mergedSplitRatio;
+      }
+    }
+
+    if (nextUi.widgetPosition || nextUi.debugPanel || nextUi.transcript) {
+      settings.ui = nextUi;
+    }
+  }
+
+  return settings;
+};
+
+const readLegacyWidgetPosition = (): { x: number; y: number } | undefined => {
+  if (typeof localStorage === 'undefined') return undefined;
+  try {
+    const raw = localStorage.getItem(LEGACY_WIDGET_POSITION_STORAGE_KEY);
+    if (!raw) return undefined;
+    return readWidgetPosition(JSON.parse(raw));
+  } catch {
+    return undefined;
+  }
+};
+
+const readLegacySplitRatio = (): number | undefined => {
+  if (typeof localStorage === 'undefined') return undefined;
+  try {
+    const raw = localStorage.getItem(LEGACY_MERGED_SPLIT_STORAGE_KEY);
+    if (!raw) return undefined;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed)) return undefined;
+    return clampMergedSplitRatio(parsed);
+  } catch {
+    return undefined;
+  }
+};
+
+export const loadSettingsFromStorage = (): PersistedSettings => {
+  if (typeof localStorage === 'undefined') return {};
+
+  let parsed: unknown = null;
+  try {
+    const raw = localStorage.getItem(APP_SETTINGS_STORAGE_KEY);
+    if (raw) parsed = JSON.parse(raw);
+  } catch {
+    parsed = null;
+  }
+
+  const settings = sanitizeSettings(parsed);
+  const legacyWidgetPosition = readLegacyWidgetPosition();
+  const legacySplitRatio = readLegacySplitRatio();
+
+  if (legacyWidgetPosition && !settings.ui?.widgetPosition) {
+    settings.ui = settings.ui ?? {};
+    settings.ui.widgetPosition = legacyWidgetPosition;
+  }
+
+  if (legacySplitRatio !== undefined && !settings.ui?.transcript?.mergedSplitRatio) {
+    settings.ui = settings.ui ?? {};
+    settings.ui.transcript = settings.ui.transcript ?? {};
+    settings.ui.transcript.mergedSplitRatio = legacySplitRatio;
+  }
+
+  return settings;
+};
+
+export const saveSettingsToStorage = (settings: PersistedSettings): void => {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(APP_SETTINGS_STORAGE_KEY, JSON.stringify(settings));
+  } catch {
+    // Ignore quota/security errors and keep runtime defaults.
+  }
+};


### PR DESCRIPTION
Persist application settings for UI layout, audio device selection, and model/configuration options, and restore them on load using a unified settings storage utility.

New Features:
- Add centralized settings storage utility to persist general, model, audio, and UI configuration in local storage with validation and clamping.
- Persist and restore widget position, transcript tab and split ratio, debug panel visibility and height, and various transcription/general settings across sessions.
- Preserve the selected audio input device and model between app launches when available.

Bug Fixes:
- Ensure audio device refresh retains the currently selected device if it still exists and gracefully falls back or clears selection when not available.

Enhancements:
- Refactor debug panel and transcription display components to support externally controlled layout state instead of directly reading and writing to local storage.
- Debounce settings writes to storage to reduce unnecessary local storage operations and handle hydration after device refresh completes.

Tests:
- Extend app store tests to cover device selection retention and fallback behavior.
- Add tests for the new settings storage utility to validate sanitization and legacy data migration behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent, storage-backed UI settings across sessions (widget position, transcript tabs/ratio, debug panel height/visibility, audio/model prefs) with debounced saves and hydration/flush on lifecycle events.

* **Bug Fixes**
  * Improved device refresh/selection logic with tolerant label matching and safer handling when devices are missing or enumeration errors occur.

* **Refactor**
  * Centralized settings storage and controlled UI state flow allowing external control of split ratio and debug panel height.

* **Tests**
  * Added comprehensive tests for device handling and settings persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->