### PR TITLE
feat: add wasm thread control and runtime backend/quantization/stride settings

### DIFF
--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -2,17 +2,11 @@ import { Component, For, Show } from 'solid-js';
 import { appStore } from '../stores/appStore';
 import { getModelDisplayName, MODELS } from './ModelLoadingOverlay';
 import type { AudioEngine } from '../lib/audio/types';
+import { getMaxHardwareThreads } from '../utils/hardwareThreads';
 
 const formatInterval = (ms: number) => {
   if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;
   return `${ms}ms`;
-};
-
-const getMaxHardwareThreads = () => {
-  if (typeof navigator === 'undefined' || !Number.isFinite(navigator.hardwareConcurrency)) {
-    return 4;
-  }
-  return Math.max(1, Math.floor(navigator.hardwareConcurrency));
 };
 
 /** Visible section preset for the embeddable settings content. */

--- a/src/lib/transcription/transcription.worker.ts
+++ b/src/lib/transcription/transcription.worker.ts
@@ -70,8 +70,10 @@ self.onmessage = async (e: MessageEvent) => {
                 if (!modelManager) {
                     modelManager = new ModelManager(modelCallbacks);
                 }
-                // FileList can't be easily sent, but File can be part of Transferable or just sent as is
-                await modelManager.loadLocalModel(payload);
+                await modelManager.loadLocalModel(payload.files, {
+                    cpuThreads: payload.cpuThreads,
+                    backend: payload.backend,
+                });
                 postMessage({ type: 'INIT_MODEL_DONE', id });
                 break;
 
@@ -224,6 +226,7 @@ self.onmessage = async (e: MessageEvent) => {
                         T: payload.T,
                         melBins: payload.melBins,
                     },
+                    frameStride: payload.frameStride ?? 1,
                     returnTimestamps: true,
                     enableProfiling: false,
                     timeOffset: payload.timeOffset || 0,

--- a/src/lib/transcription/types.ts
+++ b/src/lib/transcription/types.ts
@@ -6,13 +6,23 @@
 export type ModelState = 'unloaded' | 'loading' | 'ready' | 'error';
 /** Inference backend name. */
 export type BackendType = 'webgpu' | 'wasm';
+/** User-selectable model backend mode. */
+export type ModelBackendMode = 'webgpu-hybrid' | 'wasm';
+/** ONNX quantization option for encoder/decoder assets. */
+export type QuantizationMode = 'int8' | 'fp32';
 
 /** Model selection/configuration payload. */
 export interface ModelConfig {
   /** Selected model identifier or key. */
   modelId: string;
   /** Optional backend override. */
-  backend?: BackendType;
+  backend?: ModelBackendMode;
+  /** Optional ORT WASM thread count for CPU-side kernels/decoder. */
+  cpuThreads?: number;
+  /** Optional encoder quantization override. */
+  encoderQuant?: QuantizationMode;
+  /** Optional decoder quantization override. */
+  decoderQuant?: QuantizationMode;
 }
 
 
@@ -26,6 +36,8 @@ export interface ModelProgress {
   message?: string;
   /** Optional active filename. */
   file?: string;
+  /** Optional resolved runtime backend. */
+  backend?: BackendType;
 }
 
 /** Word-level transcription token with optional confidence. */

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -68,6 +68,13 @@ export interface V4MergerStats {
 
 /** Creates the root application store with state signals, setters, and UI actions. */
 export function createAppStore() {
+  const hardwareThreads = typeof navigator !== 'undefined' && Number.isFinite(navigator.hardwareConcurrency)
+    ? Math.max(1, Math.floor(navigator.hardwareConcurrency))
+    : 4;
+  const defaultWasmThreads = hardwareThreads <= 2
+    ? 1
+    : Math.min(4, Math.max(2, hardwareThreads - 2));
+
   // Recording state
   const [recordingState, setRecordingState] = createSignal<RecordingState>('idle');
   const [sessionDuration, setSessionDuration] = createSignal(0);
@@ -79,6 +86,9 @@ export function createAppStore() {
   // Model state
   const [modelState, setModelState] = createSignal<ModelState>('unloaded');
   const [selectedModelId, setSelectedModelId] = createSignal('parakeet-tdt-0.6b-v2');
+  const [modelBackendMode, setModelBackendMode] = createSignal<'webgpu-hybrid' | 'wasm'>('webgpu-hybrid');
+  const [encoderQuant, setEncoderQuant] = createSignal<'int8' | 'fp32'>('int8');
+  const [decoderQuant, setDecoderQuant] = createSignal<'int8' | 'fp32'>('int8');
   const [modelProgress, setModelProgress] = createSignal(0);
   const [modelMessage, setModelMessage] = createSignal('');
   const [modelFile, setModelFile] = createSignal('');
@@ -155,6 +165,7 @@ export function createAppStore() {
   const [energyThreshold, setEnergyThreshold] = createSignal(0.08);
   // Decoder frame stride: 1 = full precision, 2 = halves decoder steps (faster, coarser timestamps)
   const [frameStride, setFrameStride] = createSignal(1);
+  const [wasmThreads, setWasmThreads] = createSignal(defaultWasmThreads);
 
   // v4 Pipeline config
   const [v4InferenceIntervalMs, setV4InferenceIntervalMs] = createSignal(480); // Transcription tick frequency in ms (320-8000)
@@ -306,6 +317,9 @@ export function createAppStore() {
     sessionDuration,
     modelState,
     selectedModelId,
+    modelBackendMode,
+    encoderQuant,
+    decoderQuant,
     modelProgress,
     modelMessage,
     modelFile,
@@ -333,6 +347,7 @@ export function createAppStore() {
     triggerInterval,
     energyThreshold,
     frameStride,
+    wasmThreads,
     // v4 config
     v4InferenceIntervalMs,
     v4SilenceFlushSec,
@@ -354,6 +369,9 @@ export function createAppStore() {
     setSelectedDeviceId,
     setModelState,
     setSelectedModelId,
+    setModelBackendMode,
+    setEncoderQuant,
+    setDecoderQuant,
     setModelProgress,
     setModelMessage,
     setModelFile,
@@ -377,6 +395,7 @@ export function createAppStore() {
     setTriggerInterval,
     setEnergyThreshold,
     setFrameStride,
+    setWasmThreads,
     // UI setters
     setShowDebugPanel,
     // v4 setters

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -8,6 +8,7 @@
 import { createSignal, createMemo, createRoot, onCleanup } from 'solid-js';
 import type { RecordingState, ModelState, BackendType } from '../types';
 import type { V4SentenceEntry } from '../lib/transcription/TranscriptionWorkerClient';
+import { getMaxHardwareThreads } from '../utils/hardwareThreads';
 
 export interface DebugToken {
   /** Stable token identifier used by debug token rendering. */
@@ -68,9 +69,7 @@ export interface V4MergerStats {
 
 /** Creates the root application store with state signals, setters, and UI actions. */
 export function createAppStore() {
-  const hardwareThreads = typeof navigator !== 'undefined' && Number.isFinite(navigator.hardwareConcurrency)
-    ? Math.max(1, Math.floor(navigator.hardwareConcurrency))
-    : 4;
+  const hardwareThreads = getMaxHardwareThreads();
   const defaultWasmThreads = hardwareThreads <= 2
     ? 1
     : Math.min(4, Math.max(2, hardwareThreads - 2));
@@ -87,7 +86,7 @@ export function createAppStore() {
   const [modelState, setModelState] = createSignal<ModelState>('unloaded');
   const [selectedModelId, setSelectedModelId] = createSignal('parakeet-tdt-0.6b-v2');
   const [modelBackendMode, setModelBackendMode] = createSignal<'webgpu-hybrid' | 'wasm'>('webgpu-hybrid');
-  const [encoderQuant, setEncoderQuant] = createSignal<'int8' | 'fp32'>('int8');
+  const [encoderQuant, setEncoderQuant] = createSignal<'int8' | 'fp32'>('fp32');
   const [decoderQuant, setDecoderQuant] = createSignal<'int8' | 'fp32'>('int8');
   const [modelProgress, setModelProgress] = createSignal(0);
   const [modelMessage, setModelMessage] = createSignal('');

--- a/src/utils/hardwareThreads.ts
+++ b/src/utils/hardwareThreads.ts
@@ -1,0 +1,10 @@
+export const getMaxHardwareThreads = (): number => {
+  if (typeof navigator === 'undefined' || !Number.isFinite(navigator.hardwareConcurrency)) {
+    return 4;
+  }
+  return Math.max(1, Math.floor(navigator.hardwareConcurrency));
+};
+
+export const clampWasmThreadsForDevice = (value: number): number =>
+  Math.max(1, Math.min(getMaxHardwareThreads(), Math.floor(value)));
+

--- a/src/utils/settingsStorage.test.ts
+++ b/src/utils/settingsStorage.test.ts
@@ -23,8 +23,15 @@ describe('settingsStorage', () => {
         v4InferenceIntervalMs: 9000,
         v4SilenceFlushSec: -4,
         streamingWindow: 1.2,
+        frameStride: 99,
+        wasmThreads: 999,
       },
-      model: { selectedModelId: 'parakeet-tdt-0.6b-v2' },
+      model: {
+        selectedModelId: 'parakeet-tdt-0.6b-v2',
+        backend: 'invalid',
+        encoderQuant: 'fp32',
+        decoderQuant: 'int8',
+      },
       audio: { selectedDeviceId: 'device-1', selectedDeviceLabel: 'Mic 1' },
       ui: {
         widgetPosition: { x: 12, y: 18 },
@@ -40,7 +47,12 @@ describe('settingsStorage', () => {
     expect(loaded.general?.v4InferenceIntervalMs).toBe(8000);
     expect(loaded.general?.v4SilenceFlushSec).toBe(0.3);
     expect(loaded.general?.streamingWindow).toBe(2);
+    expect(loaded.general?.frameStride).toBe(4);
+    expect(loaded.general?.wasmThreads).toBe(64);
     expect(loaded.model?.selectedModelId).toBe('parakeet-tdt-0.6b-v2');
+    expect(loaded.model?.backend).toBeUndefined();
+    expect(loaded.model?.encoderQuant).toBe('fp32');
+    expect(loaded.model?.decoderQuant).toBe('int8');
     expect(loaded.audio?.selectedDeviceId).toBe('device-1');
     expect(loaded.ui?.widgetPosition).toEqual({ x: 12, y: 18 });
     expect(loaded.ui?.debugPanel?.visible).toBe(true);

--- a/vite.config.js
+++ b/vite.config.js
@@ -84,7 +84,7 @@ export default defineConfig({
   ],
   server: {
     port: 5173,
-    host: 'localhost',
+    host: process.env.DEV_HOST || '0.0.0.0',
     headers: {
       'Cross-Origin-Embedder-Policy': 'require-corp',
       'Cross-Origin-Opener-Policy': 'same-origin',

--- a/vite.config.js
+++ b/vite.config.js
@@ -83,8 +83,8 @@ export default defineConfig({
     solidPlugin()
   ],
   server: {
-    port: 3100,
-    host: '0.0.0.0',
+    port: 5173,
+    host: 'localhost',
     headers: {
       'Cross-Origin-Embedder-Policy': 'require-corp',
       'Cross-Origin-Opener-Policy': 'same-origin',


### PR DESCRIPTION
Summary
- add configurable WASM thread count setting in UI and persist it
- pass cpu thread count through ModelManager to ParakeetModel loading
- expose runtime backend selection and encoder/decoder quantization choices
- expose decoder frame stride setting and wire it through inference path

Notes
- keeps fragile v4 interval/window-cap logic untouched
- intended to reduce laptop CPU/fan pressure while preserving real-time headroom