### PR TITLE
Performance: Remove redundant buffer allocation in AudioEngine visualization loop

### DIFF
--- a/src/lib/audio/AudioEngine.ts
+++ b/src/lib/audio/AudioEngine.ts
@@ -925,8 +925,9 @@ export class AudioEngine implements IAudioEngine {
         if (!this.visualizationNotifyBuffer || this.visualizationNotifyBuffer.length !== targetSize) {
             this.visualizationNotifyBuffer = new Float32Array(targetSize);
         }
-        const data = this.getVisualizationData(targetWidth, this.visualizationNotifyBuffer);
-        const payload = data.slice();
+        // Zero-allocation: Pass internal buffer directly.
+        // Consumers must copy if they need persistence (BufferVisualizer does this).
+        const payload = this.getVisualizationData(targetWidth, this.visualizationNotifyBuffer);
 
         const bufferEndTime = this.ringBuffer.getCurrentTime();
         this.visualizationCallbacks.forEach((cb) => cb(payload, this.getMetrics(), bufferEndTime));


### PR DESCRIPTION
- **Optimization**: Removed `.slice()` from `notifyVisualizationUpdate` in `AudioEngine.ts`. This eliminates a `Float32Array` allocation (~3.2KB) every ~33ms (30fps), reducing GC pressure by ~100KB/s.
- **Contract Change**: The visualization callback now receives a direct reference to the internal `visualizationNotifyBuffer`. This buffer is reused across frames.
- **Safety**: Consumers like `BufferVisualizer` immediately copy the data (`new Float32Array(data)`), and `App.tsx` ignores the data, so this change is safe.
- **Testing**: Updated `AudioEngine.visualization.test.ts` to verify the zero-copy behavior (expecting buffer reuse instead of stable snapshots).
- **Verification**: Verified with `pnpm test src/lib/audio/AudioEngine.visualization.test.ts` and `pnpm test` (all passed).
- **Note**: `pnpm build` fails due to pre-existing missing `tailwindcss` dependency, unrelated to this change.

---
*PR created automatically by Jules for task [14450505226091082859](https://jules.google.com/task/14450505226091082859) started by @ysdede*

## Summary by Sourcery

Optimize audio visualization updates by eliminating redundant buffer copies and updating tests for the new zero-copy behavior.

Enhancements:
- Pass the internal visualization buffer directly to visualization callbacks to avoid per-frame allocations and reduce GC pressure.

Tests:
- Update AudioEngine visualization tests to assert buffer reuse and mutable snapshot behavior under the zero-copy contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized audio visualization updates to reduce memory allocations by reusing internal buffers instead of creating copies.

* **Breaking Changes**
  * Audio visualization data consumers must now explicitly copy data if they need to retain it across update cycles; data is no longer guaranteed to persist after the next update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->