### PR TITLE
Performance: Zero-allocation BufferVisualizer update loop

### DIFF
--- a/src/components/BufferVisualizer.tsx
+++ b/src/components/BufferVisualizer.tsx
@@ -32,7 +32,8 @@ export const BufferVisualizer: Component<BufferVisualizerProps> = (props) => {
   // State
   const [isDarkSignal, setIsDarkSignal] = createSignal(false);
   const [canvasWidth, setCanvasWidth] = createSignal(0);
-  const [waveformData, setWaveformData] = createSignal<Float32Array>(new Float32Array(0));
+  // Use { equals: false } because we reuse the same buffer reference for performance
+  const [waveformData, setWaveformData] = createSignal<Float32Array>(new Float32Array(0), { equals: false });
   const [metrics, setMetrics] = createSignal<AudioMetrics>({
     currentEnergy: 0,
     averageEnergy: 0,
@@ -435,7 +436,9 @@ export const BufferVisualizer: Component<BufferVisualizerProps> = (props) => {
       // Subscribe to updates
       const sub = engine.onVisualizationUpdate((data, newMetrics, endTime) => {
         if (visible()) {
-          setWaveformData(new Float32Array(data));
+          // Optimization: Reuse shared buffer from AudioEngine to avoid GC.
+          // The buffer content is mutable and updated in place by the engine.
+          setWaveformData(data);
           setMetrics(newMetrics);
           setBufferEndTime(endTime);
 


### PR DESCRIPTION
Identified a performance bottleneck in `BufferVisualizer.tsx` where a new `Float32Array` was allocated on every animation frame (via `onVisualizationUpdate` subscription). This caused unnecessary garbage collection pressure (~3KB per frame at 30fps).

Implemented a zero-allocation strategy by directly passing the shared mutable buffer from `AudioEngine` to the `waveformData` signal. Configured the signal with `{ equals: false }` to guarantee reactivity even when the buffer reference remains stable.

Verified using a custom unit test that spies on `Float32Array` constructor calls, confirming allocations dropped to zero during the update loop. Frontend verification confirmed the visualizer still renders correctly.