### PR TITLE
staging: integrate reviewed leftovers (tests + type-safety)

### DIFF
--- a/src/lib/audio/AudioSegmentProcessor.test.ts
+++ b/src/lib/audio/AudioSegmentProcessor.test.ts
@@ -88,6 +88,30 @@ describe('AudioSegmentProcessor', () => {
         expect(state.noiseFloor).toBeGreaterThan(0);
     });
 
+    it('should mark speech start at or before the first speech frame after silence', () => {
+        const processor = createProcessor({
+            energyThreshold: 0.01,
+            snrThreshold: 0,
+            minSnrThreshold: 0,
+        });
+        const silenceChunk = new Float32Array(CHUNK_SIZE).fill(0);
+        const speechChunk = new Float32Array(CHUNK_SIZE).fill(SPEECH_ENERGY);
+
+        // Stabilize noise floor and history with silence first.
+        for (let i = 0; i < 10; i++) {
+            processor.processAudioData(silenceChunk, (i + 1) * CHUNK_DURATION_SEC, SILENCE_ENERGY);
+        }
+
+        const speechStartTime = 11 * CHUNK_DURATION_SEC;
+        processor.processAudioData(speechChunk, speechStartTime, SPEECH_ENERGY);
+
+        const state = processor.getStateInfo();
+        expect(state.inSpeech).toBe(true);
+        expect(state.speechStartTime).not.toBeNull();
+        // Lookback can move start earlier, but never later than detected speech frame.
+        expect(state.speechStartTime!).toBeLessThanOrEqual(speechStartTime);
+    });
+
     it('should end speech after configured silence threshold', () => {
         const silenceThresholdSec = 0.16;
         const processor = createProcessor({

--- a/src/lib/audio/mel.worker.ts
+++ b/src/lib/audio/mel.worker.ts
@@ -404,9 +404,10 @@ self.onmessage = (e: MessageEvent) => {
             default:
                 console.warn('[MelWorker] Unknown message type:', type);
         }
-    } catch (err: any) {
+    } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
         console.error('[MelWorker] Error:', err);
-        postMessage({ type: 'ERROR', payload: err.message, id });
+        postMessage({ type: 'ERROR', payload: message, id });
     }
 };
 

--- a/src/lib/transcription/transcription.worker.ts
+++ b/src/lib/transcription/transcription.worker.ts
@@ -312,9 +312,10 @@ self.onmessage = async (e: MessageEvent) => {
             default:
                 console.warn('[TranscriptionWorker] Unknown message type:', type);
         }
-    } catch (err: any) {
+    } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
         console.error('[TranscriptionWorker] Error:', err);
-        postMessage({ type: 'ERROR', payload: err.message, id });
+        postMessage({ type: 'ERROR', payload: message, id });
     }
 };
 


### PR DESCRIPTION
This staging integration branch applies the safe remainder after PR cleanup.

Included (in order):
1. Added `AudioSegmentProcessor` onset regression coverage after sustained silence.
2. Replaced remaining worker-side `catch (err: any)` with safe `unknown` handling in:
   - `src/lib/audio/mel.worker.ts`
   - `src/lib/transcription/transcription.worker.ts`

Validation
- `npm exec vitest run src/lib/audio/AudioSegmentProcessor.test.ts`
- `npm run build`

Summary
Improve audio processing robustness and error handling in workers.

### New features
- Add regression coverage to ensure `AudioSegmentProcessor` correctly detects speech onset after sustained silence.

### Enhancements
- Harden worker error handling in mel and transcription workers by treating caught errors as `unknown` and safely extracting a message before posting error responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Summary by CodeRabbit

Release Notes

* **Tests**
  * Expanded test coverage for speech detection timing to ensure accuracy after silence periods.

* **Improvements**
  * Enhanced error handling in audio and transcription processing with more robust and safer error message extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->