### PR TITLE
fix: close critical cleanup leaks (#118 #119 #120 #121)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -550,6 +550,9 @@ const App: Component = () => {
     cleanupV4Pipeline();
     melClient?.dispose();
     workerClient?.dispose();
+    audioEngine?.dispose();
+    audioEngine = null;
+    setAudioEngineSignal(null);
   });
 
   // ---- v4 pipeline tick: periodic window building + inference ----

--- a/src/components/BufferVisualizer.tsx
+++ b/src/components/BufferVisualizer.tsx
@@ -52,11 +52,28 @@ export const BufferVisualizer: Component<BufferVisualizerProps> = (props) => {
   const showTimeMarkers = () => props.showTimeMarkers ?? true;
   const visible = () => props.visible ?? true;
 
-  let animationFrameId: number | undefined;
+  let rafId: number | undefined;
+  let timeoutId: number | undefined;
   let resizeObserver: ResizeObserver | null = null;
   let needsRedraw = true;
   let lastDrawTime = 0;
   const DRAW_INTERVAL_MS = 33;
+
+  const scheduleRaf = () => {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+      timeoutId = undefined;
+    }
+    rafId = requestAnimationFrame(drawLoop);
+  };
+
+  const scheduleTimeout = () => {
+    if (rafId !== undefined) {
+      cancelAnimationFrame(rafId);
+      rafId = undefined;
+    }
+    timeoutId = window.setTimeout(drawLoop, 100);
+  };
 
   // Draw function
   const draw = () => {
@@ -382,9 +399,9 @@ export const BufferVisualizer: Component<BufferVisualizerProps> = (props) => {
   const drawLoop = () => {
     if (!ctx || !canvasRef || canvasRef.width === 0) {
       if (visible()) {
-        animationFrameId = requestAnimationFrame(drawLoop);
+        scheduleRaf();
       } else {
-        animationFrameId = window.setTimeout(drawLoop, 100) as unknown as number;
+        scheduleTimeout();
       }
       return;
     }
@@ -396,10 +413,10 @@ export const BufferVisualizer: Component<BufferVisualizerProps> = (props) => {
         needsRedraw = false;
         draw();
       }
-      animationFrameId = requestAnimationFrame(drawLoop);
+      scheduleRaf();
     } else {
       // When not visible, check less frequently to save CPU
-      animationFrameId = window.setTimeout(drawLoop, 100) as unknown as number;
+      scheduleTimeout();
     }
   };
 
@@ -487,13 +504,21 @@ export const BufferVisualizer: Component<BufferVisualizerProps> = (props) => {
     }
 
     // Start animation loop
-    animationFrameId = requestAnimationFrame(drawLoop);
+    if (visible()) {
+      scheduleRaf();
+    } else {
+      scheduleTimeout();
+    }
   });
 
   onCleanup(() => {
-    if (animationFrameId) {
-      cancelAnimationFrame(animationFrameId);
-      clearTimeout(animationFrameId);
+    if (rafId !== undefined) {
+      cancelAnimationFrame(rafId);
+      rafId = undefined;
+    }
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+      timeoutId = undefined;
     }
     if (resizeObserver) {
       resizeObserver.disconnect();

--- a/src/lib/audio/AudioEngine.ts
+++ b/src/lib/audio/AudioEngine.ts
@@ -518,6 +518,17 @@ export class AudioEngine implements IAudioEngine {
 
     dispose(): void {
         this.stop();
+        if (this.workletNode) {
+            this.workletNode.port.onmessage = null;
+            this.workletNode.onprocessorerror = null;
+            try {
+                this.workletNode.port.close();
+            } catch {
+                // Ignore if port is already closed/disconnected.
+            }
+            this.workletNode.disconnect();
+        }
+        this.sourceNode?.disconnect();
         this.disposeAnalyser();
         this.mediaStream?.getTracks().forEach(track => track.stop());
         this.audioContext?.close();

--- a/src/lib/transcription/TranscriptionWorkerClient.test.ts
+++ b/src/lib/transcription/TranscriptionWorkerClient.test.ts
@@ -103,4 +103,10 @@ describe('TranscriptionWorkerClient', () => {
         const file = new File([''], 'model.onnx');
         await expect(client.initLocalModel([file])).resolves.toBeUndefined();
     });
+
+    it('should reject pending requests when disposed', async () => {
+        const pending = client.initService({ sampleRate: 16000 });
+        client.dispose();
+        await expect(pending).rejects.toThrow('TranscriptionWorkerClient disposed');
+    });
 });

--- a/src/lib/transcription/TranscriptionWorkerClient.ts
+++ b/src/lib/transcription/TranscriptionWorkerClient.ts
@@ -306,7 +306,12 @@ export class TranscriptionWorkerClient {
     }
 
     dispose() {
+        this.worker.onmessage = null;
+        this.worker.onerror = null;
         this.worker.terminate();
+        for (const [, pending] of this.pendingPromises) {
+            pending.reject(new Error('TranscriptionWorkerClient disposed'));
+        }
         this.pendingPromises.clear();
     }
 }


### PR DESCRIPTION
Summary
Fixes four critical lifecycle/leak issues in audio + worker cleanup paths.

### What changed
- `App.tsx`
  - Dispose `audioEngine` on app cleanup.
  - Clear module-level reference and signal (`audioEngine = null`, `setAudioEngineSignal(null)`).
- `AudioEngine.dispose()`
  - Clear `workletNode.port.onmessage`.
  - Clear `workletNode.onprocessorerror`.
  - Close worklet port safely and disconnect worklet/source nodes.
- `BufferVisualizer.tsx`
  - Split scheduler ids into `rafId` and `timeoutId`.
  - Cancel/clear the correct handle type in all transitions and cleanup.
- `TranscriptionWorkerClient.dispose()`
  - Reject all pending promises with `TranscriptionWorkerClient disposed` before clearing map.
  - Clear worker handlers before terminate.
- `TranscriptionWorkerClient.test.ts`
  - Added regression test: pending request rejects on dispose.

Validation
- `npm run test -- src/lib/transcription/TranscriptionWorkerClient.test.ts src/lib/audio/AudioEngine.visualization.test.ts`
- `npm run build`

Closes #118
Closes #119
Closes #120
Closes #121