### PR TITLE
fix(transcription): harden dispose/sendRequest error paths

### DIFF
--- a/src/lib/transcription/TranscriptionWorkerClient.test.ts
+++ b/src/lib/transcription/TranscriptionWorkerClient.test.ts
@@ -5,10 +5,14 @@ import { TranscriptionWorkerClient } from './TranscriptionWorkerClient';
 class MockWorker {
     onmessage: ((this: Worker, ev: MessageEvent) => any) | null = null;
     onerror: ((this: Worker, ev: ErrorEvent) => any) | null = null;
+    static throwOnPostMessage = false;
 
     constructor(stringUrl: string | URL, options?: WorkerOptions) {}
 
     postMessage(data: any) {
+        if (MockWorker.throwOnPostMessage) {
+            throw new Error('postMessage failed');
+        }
         // Simulate async response
         setTimeout(() => {
             if (this.onmessage) {
@@ -67,6 +71,7 @@ describe('TranscriptionWorkerClient', () => {
     });
 
     beforeEach(() => {
+        MockWorker.throwOnPostMessage = false;
         client = new TranscriptionWorkerClient();
     });
 
@@ -108,5 +113,16 @@ describe('TranscriptionWorkerClient', () => {
         const pending = client.initService({ sampleRate: 16000 });
         client.dispose();
         await expect(pending).rejects.toThrow('TranscriptionWorkerClient disposed');
+    });
+
+    it('should reject requests after disposal', async () => {
+        client.dispose();
+        await expect(client.initService({ sampleRate: 16000 })).rejects.toThrow('TranscriptionWorkerClient disposed');
+    });
+
+    it('should reject and cleanup pending map when postMessage throws', async () => {
+        MockWorker.throwOnPostMessage = true;
+        await expect(client.initService({ sampleRate: 16000 })).rejects.toThrow('postMessage failed');
+        expect((client as any).pendingPromises.size).toBe(0);
     });
 });

--- a/src/lib/transcription/TranscriptionWorkerClient.ts
+++ b/src/lib/transcription/TranscriptionWorkerClient.ts
@@ -103,6 +103,7 @@ export class TranscriptionWorkerClient {
     private worker: Worker;
     private messageId = 0;
     private pendingPromises: Map<number, { resolve: Function; reject: Function }> = new Map();
+    private disposed = false;
 
     // Callbacks for reactive updates
     public onModelProgress?: (p: ModelProgress) => void;
@@ -165,10 +166,22 @@ export class TranscriptionWorkerClient {
         payload?: WorkerMessageMap[T]['payload'],
         transfer?: Transferable[]
     ): Promise<WorkerMessageMap[T]['response']> {
+        if (this.disposed) {
+            return Promise.reject(new Error('TranscriptionWorkerClient disposed'));
+        }
         const id = this.messageId++;
         return new Promise((resolve, reject) => {
+            if (this.disposed) {
+                reject(new Error('TranscriptionWorkerClient disposed'));
+                return;
+            }
             this.pendingPromises.set(id, { resolve, reject });
-            this.worker.postMessage({ type, payload, id }, transfer || []);
+            try {
+                this.worker.postMessage({ type, payload, id }, transfer || []);
+            } catch (err) {
+                this.pendingPromises.delete(id);
+                reject(err instanceof Error ? err : new Error(String(err)));
+            }
         });
     }
 
@@ -306,13 +319,17 @@ export class TranscriptionWorkerClient {
     }
 
     dispose() {
+        if (this.disposed) return;
+        this.disposed = true;
         this.worker.onmessage = null;
         this.worker.onerror = null;
         this.worker.terminate();
-        for (const [, pending] of this.pendingPromises) {
-            pending.reject(new Error('TranscriptionWorkerClient disposed'));
-        }
+        const pending = Array.from(this.pendingPromises.values());
         this.pendingPromises.clear();
+        for (const entry of pending) {
+            // Reject pending callers so await chains don't hang after teardown.
+            entry.reject(new Error('TranscriptionWorkerClient disposed'));
+        }
     }
 }
 


### PR DESCRIPTION
Summary
Hardens `TranscriptionWorkerClient` teardown and request handling after review feedback.

### Changes
- Adds a `disposed` guard so public request paths fail fast after teardown.
- Wraps `worker.postMessage` in `try/catch` and removes pending map entries on failure.
- Makes `dispose()` idempotent.
- Uses snapshot+clear pattern when rejecting pending promises during dispose.
- Adds regression tests for:
  - requests rejected after dispose,
  - pending map cleanup when `postMessage` throws.

Why
This addresses a real hardening gap independent of v4 merger logic:
- prevents post-dispose accidental usage,
- prevents stale `pendingPromises` entries on `postMessage` errors.

Validation
- `npm run test -- src/lib/transcription/TranscriptionWorkerClient.test.ts`
- `npm run build`