### PR TITLE
perf: progress on #111 wasm warm-up and #114 jank reduction

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -310,6 +310,11 @@ const App: Component = () => {
   let onBeforeUnload: (() => void) | undefined;
   let onPageHide: (() => void) | undefined;
   let onVisibilityChange: (() => void) | undefined;
+  let warmupIdleHandle: number | null = null;
+  let warmupTimeoutHandle: number | undefined;
+  let removeWarmupGestureListeners: (() => void) | null = null;
+  let warmupCancelled = false;
+  let warmupStarted = false;
 
   const isRecording = () => appStore.recordingState() === 'recording';
   const isModelReady = () => appStore.modelState() === 'ready';
@@ -478,6 +483,77 @@ const App: Component = () => {
     saveSettingsToStorage(getSettingsSnapshot());
   };
 
+  const cancelWasmWarmupSchedule = () => {
+    if (warmupIdleHandle !== null && typeof window !== 'undefined' && 'cancelIdleCallback' in window) {
+      (window as any).cancelIdleCallback(warmupIdleHandle);
+      warmupIdleHandle = null;
+    }
+    if (warmupTimeoutHandle !== undefined) {
+      clearTimeout(warmupTimeoutHandle);
+      warmupTimeoutHandle = undefined;
+    }
+  };
+
+  const runWasmWarmup = async () => {
+    if (warmupCancelled || warmupStarted) return;
+    if (isRecording() || appStore.modelState() === 'loading') {
+      scheduleWasmWarmup();
+      return;
+    }
+
+    warmupStarted = true;
+    const warmupClient = new TenVADWorkerClient();
+    try {
+      const wasmPath = `${import.meta.env.BASE_URL}wasm/`;
+      await warmupClient.init({ hopSize: 256, threshold: 0.5, wasmPath });
+      await warmupClient.reset();
+      console.debug('[perf] TEN-VAD wasm warm-up complete');
+    } catch (err) {
+      console.debug('[perf] TEN-VAD wasm warm-up skipped:', err);
+    } finally {
+      warmupClient.dispose();
+    }
+  };
+
+  const scheduleWasmWarmup = () => {
+    cancelWasmWarmupSchedule();
+    if (typeof window !== 'undefined' && 'requestIdleCallback' in window) {
+      warmupIdleHandle = (window as any).requestIdleCallback(() => {
+        warmupIdleHandle = null;
+        void runWasmWarmup();
+      }, { timeout: 2500 });
+      return;
+    }
+    warmupTimeoutHandle = window.setTimeout(() => {
+      warmupTimeoutHandle = undefined;
+      void runWasmWarmup();
+    }, 1200);
+  };
+
+  const armWasmWarmupOnFirstGesture = () => {
+    if (typeof window === 'undefined') return;
+    let armed = true;
+    const onGesture = () => {
+      if (!armed) return;
+      armed = false;
+      scheduleWasmWarmup();
+      removeWarmupGestureListeners?.();
+      removeWarmupGestureListeners = null;
+    };
+
+    const addOpts: AddEventListenerOptions = { passive: true };
+    document.addEventListener('pointerdown', onGesture, addOpts);
+    document.addEventListener('touchstart', onGesture, addOpts);
+    document.addEventListener('keydown', onGesture);
+
+    removeWarmupGestureListeners = () => {
+      armed = false;
+      document.removeEventListener('pointerdown', onGesture);
+      document.removeEventListener('touchstart', onGesture);
+      document.removeEventListener('keydown', onGesture);
+    };
+  };
+
   createEffect(() => {
     if (!settingsReadyForPersist()) return;
     const snapshot = getSettingsSnapshot();
@@ -534,6 +610,7 @@ const App: Component = () => {
       setSettingsReadyForPersist(true);
     });
     setWorkerReady(true);
+    armWasmWarmupOnFirstGesture();
   });
 
   // No longer auto-show blocking model overlay; model selection is in the settings panel.
@@ -545,6 +622,10 @@ const App: Component = () => {
     if (onPageHide) window.removeEventListener('pagehide', onPageHide);
     if (onVisibilityChange) document.removeEventListener('visibilitychange', onVisibilityChange);
     clearTimeout(panelHoverCloseTimeout);
+    warmupCancelled = true;
+    cancelWasmWarmupSchedule();
+    removeWarmupGestureListeners?.();
+    removeWarmupGestureListeners = null;
     flushSettingsSave();
     visualizationUnsubscribe?.();
     cleanupV4Pipeline();

--- a/src/components/LayeredBufferVisualizer.tsx
+++ b/src/components/LayeredBufferVisualizer.tsx
@@ -75,8 +75,12 @@ export const LayeredBufferVisualizer: Component<LayeredBufferVisualizerProps> = 
 
     // State for last fetch to throttle spectrogram updates
     let lastSpecFetchTime = 0;
-    const SPEC_FETCH_INTERVAL = 100; // Update spectrogram every 100ms (10fps)
-    const DRAW_INTERVAL_MS = 33; // Throttle full redraw to ~30fps
+    const DRAW_INTERVAL_FOREGROUND_MS = 33;
+    const DRAW_INTERVAL_IDLE_MS = 100;
+    const DRAW_INTERVAL_HIDDEN_MS = 220;
+    const SPEC_FETCH_INTERVAL_FOREGROUND_MS = 100;
+    const SPEC_FETCH_INTERVAL_IDLE_MS = 250;
+    const SPEC_FETCH_INTERVAL_HIDDEN_MS = 700;
     let lastDrawTime = 0;
 
     // --- Cached layout dimensions (updated via ResizeObserver, NOT per-frame) ---
@@ -195,7 +199,14 @@ export const LayeredBufferVisualizer: Component<LayeredBufferVisualizerProps> = 
             return;
         }
 
-        if (now - lastDrawTime < DRAW_INTERVAL_MS) {
+        const hidden = typeof document !== 'undefined' && document.visibilityState !== 'visible';
+        const recording = appStore.recordingState() === 'recording';
+        const drawInterval = hidden
+            ? DRAW_INTERVAL_HIDDEN_MS
+            : recording
+                ? DRAW_INTERVAL_FOREGROUND_MS
+                : DRAW_INTERVAL_IDLE_MS;
+        if (now - lastDrawTime < drawInterval) {
             animationFrameId = requestAnimationFrame(loop);
             return;
         }
@@ -234,7 +245,12 @@ export const LayeredBufferVisualizer: Component<LayeredBufferVisualizerProps> = 
 
         // 1. Spectrogram (async fetch with stored alignment)
         if (props.melClient && specCtx && specCanvas) {
-            if (now - lastSpecFetchTime > SPEC_FETCH_INTERVAL) {
+            const specFetchInterval = hidden
+                ? SPEC_FETCH_INTERVAL_HIDDEN_MS
+                : recording
+                    ? SPEC_FETCH_INTERVAL_FOREGROUND_MS
+                    : SPEC_FETCH_INTERVAL_IDLE_MS;
+            if (now - lastSpecFetchTime > specFetchInterval) {
                 lastSpecFetchTime = now;
 
                 const fetchStartSample = Math.round(startTime * sampleRate);

--- a/src/components/Waveform.tsx
+++ b/src/components/Waveform.tsx
@@ -18,9 +18,10 @@ export const Waveform: Component<WaveformProps> = (props) => {
   let canvasRef: HTMLCanvasElement | undefined;
   let ctx: CanvasRenderingContext2D | null = null;
   let animationId: number | undefined;
+  let timeoutId: number | undefined;
   let resizeObserver: ResizeObserver | null = null;
+  let themeObserver: MutationObserver | null = null;
   let lastDrawTs = 0;
-  let lastStyleRefreshTs = 0;
   let bgColor = '#faf8f5';
   let strokeColor = '#14b8a6';
   const FOREGROUND_FRAME_MS = 33;
@@ -46,9 +47,28 @@ export const Waveform: Component<WaveformProps> = (props) => {
     strokeColor = computed.getPropertyValue('--color-primary').trim() || '#14b8a6';
   };
 
+  const scheduleNextFrame = (hidden: boolean, recording: boolean) => {
+    if (!hidden && recording) {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+        timeoutId = undefined;
+      }
+      animationId = requestAnimationFrame(animate);
+      return;
+    }
+    if (animationId !== undefined) {
+      cancelAnimationFrame(animationId);
+      animationId = undefined;
+    }
+    const nextDelay = hidden ? HIDDEN_FRAME_MS : IDLE_FRAME_MS;
+    timeoutId = window.setTimeout(() => animate(performance.now()), nextDelay);
+  };
+
   const animate = (ts: number) => {
-    animationId = requestAnimationFrame(animate);
-    if (!ctx || !canvasRef) return;
+    if (!ctx || !canvasRef) {
+      scheduleNextFrame(false, props.isRecording);
+      return;
+    }
 
     const hidden = typeof document !== 'undefined' && document.visibilityState !== 'visible';
     const minFrameInterval = hidden
@@ -56,17 +76,18 @@ export const Waveform: Component<WaveformProps> = (props) => {
       : props.isRecording
         ? FOREGROUND_FRAME_MS
         : IDLE_FRAME_MS;
-    if (ts - lastDrawTs < minFrameInterval) return;
-    lastDrawTs = ts;
-
-    if (ts - lastStyleRefreshTs > 1000) {
-      refreshThemeColors();
-      lastStyleRefreshTs = ts;
+    if (ts - lastDrawTs < minFrameInterval) {
+      scheduleNextFrame(hidden, props.isRecording);
+      return;
     }
+    lastDrawTs = ts;
 
     const w = canvasRef.width;
     const h = canvasRef.height;
-    if (w === 0 || h === 0) return;
+    if (w === 0 || h === 0) {
+      scheduleNextFrame(hidden, props.isRecording);
+      return;
+    }
 
     const samples = props.barLevels;
     const n = samples && samples.length > 0 ? samples.length : 0;
@@ -89,6 +110,8 @@ export const Waveform: Component<WaveformProps> = (props) => {
       }
       ctx.stroke();
     }
+
+    scheduleNextFrame(hidden, props.isRecording);
   };
 
   onMount(() => {
@@ -100,14 +123,25 @@ export const Waveform: Component<WaveformProps> = (props) => {
         resizeObserver.observe(canvasRef.parentElement ?? canvasRef);
       }
     }
-    animationId = requestAnimationFrame(animate);
+    if (typeof document !== 'undefined') {
+      themeObserver = new MutationObserver(() => refreshThemeColors());
+      themeObserver.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ['class'],
+      });
+    }
+    animate(performance.now());
   });
 
   onCleanup(() => {
     if (animationId !== undefined) {
       cancelAnimationFrame(animationId);
     }
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
     resizeObserver?.disconnect();
+    themeObserver?.disconnect();
   });
 
   return (


### PR DESCRIPTION
Summary
Performance-focused follow-up for #111 and #114 without touching v4 merger/window/cursor logic.

What changed
- `src/App.tsx`
  - Added one-shot TEN-VAD WASM warm-up flow, triggered after first user gesture.
  - Warm-up runs in idle time (`requestIdleCallback` fallback to timeout).
  - Warm-up is cancelled on app cleanup and deferred while recording/model-loading.
- `src/components/Waveform.tsx`
  - Replaced always-rAF loop with adaptive scheduling:
    - rAF only when visible + recording
    - timeout loop for idle/hidden states
  - Replaced periodic style polling (`getComputedStyle` every second) with theme class observer.
- `src/components/LayeredBufferVisualizer.tsx`
  - Added adaptive draw/fetch intervals based on `recording` and tab visibility.
  - Keeps full-rate behavior while recording/visible; slows in idle/hidden modes.

Why
- #111: move WASM compile cost off first recording path by warming TEN-VAD at low-priority idle time.
- #114: lower continuous canvas/render pressure in non-critical states to reduce jank spikes.

Validation
- `npm run test -- src/lib/transcription/TranscriptionWorkerClient.test.ts`
- `npm run build`

Notes
- This PR is intentionally scoped to safe perf changes.
- v4 merger/cursor/window semantics are unchanged.
- Recommended next step is a fresh trace run to verify acceptance metrics for #111/#114.

Related #111
Related #114