### PR TITLE
chore: resolve low-hanging safe cleanup issues

### DIFF
--- a/src/components/ContextPanel.tsx
+++ b/src/components/ContextPanel.tsx
@@ -11,7 +11,7 @@ interface ContextPanelProps {
   onLoadModel: () => void;
   /** Opens the developer/debug panel. */
   onOpenDebug: () => void;
-  /** Called when the selected input device changes. */
+  /** @internal Called by App when the selected input device changes. */
   onDeviceSelect?: (id: string) => void;
 }
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -21,8 +21,6 @@ interface SidebarProps {
   selectedDeviceId: string;
   /** Updates the selected microphone device. */
   onDeviceSelect: (id: string) => void;
-  /** Current normalized input level (0-1). */
-  audioLevel: number;
 }
 
 /** Left rail with recording, model, and device actions. */

--- a/src/components/Waveform.tsx
+++ b/src/components/Waveform.tsx
@@ -1,15 +1,5 @@
 import { Component, onCleanup, onMount } from 'solid-js';
-
-interface WaveformProps {
-  /** Normalized audio level used by parent UI widgets. */
-  audioLevel: number;
-  /** Oscilloscope samples: Float32Array -1..1 from getByteTimeDomainData */
-  barLevels?: Float32Array;
-  /** Recording state used to throttle drawing when idle/backgrounded. */
-  isRecording: boolean;
-  /** Optional sample count hint for compact renderers. */
-  barCount?: number;
-}
+import type { WaveformProps } from '../types';
 
 /**
  * Oscilloscope-style waveform using AnalyserNode.getByteTimeDomainData (native, fast).
@@ -156,7 +146,7 @@ export const SPECTRUM_BAR_COUNT = 128;
 
 /** Compact wrapper around `Waveform` with defaults for tight layouts. */
 export const CompactWaveform: Component<WaveformProps> = (props) => (
-  <Waveform {...props} barCount={props.barLevels?.length} />
+  <Waveform {...props} />
 );
 
 export default Waveform;

--- a/src/components/Waveform.tsx
+++ b/src/components/Waveform.tsx
@@ -141,9 +141,6 @@ export const Waveform: Component<WaveformProps> = (props) => {
   );
 };
 
-/** Default number of bars used by compact spectrum-like waveform renderers. */
-export const SPECTRUM_BAR_COUNT = 128;
-
 /** Compact wrapper around `Waveform` with defaults for tight layouts. */
 export const CompactWaveform: Component<WaveformProps> = (props) => (
   <Waveform {...props} />

--- a/src/index.css
+++ b/src/index.css
@@ -21,10 +21,10 @@
   --font-story: "Crimson Pro", serif;
 
   /* Softer shadows for earthy theme */
-  --shadow-neu-flat: 4px 4px 10px rgba(183, 183, 164, 0.25), -4px -4px 10px rgba(255, 255, 255, 0.8);
-  --shadow-neu-pressed: inset 3px 3px 6px rgba(183, 183, 164, 0.2), inset -3px -3px 6px rgba(255, 255, 255, 0.6);
-  --shadow-neu-btn: 3px 3px 8px rgba(183, 183, 164, 0.2), -3px -3px 8px rgba(255, 255, 255, 0.7);
-  --shadow-neu-btn-hover: 2px 2px 5px rgba(183, 183, 164, 0.2), -2px -2px 5px rgba(255, 255, 255, 0.6);
+  --shadow-neu-flat: 4px 4px 10px rgb(183 183 164 / 25%), -4px -4px 10px rgb(255 255 255 / 80%);
+  --shadow-neu-pressed: inset 3px 3px 6px rgb(183 183 164 / 20%), inset -3px -3px 6px rgb(255 255 255 / 60%);
+  --shadow-neu-btn: 3px 3px 8px rgb(183 183 164 / 20%), -3px -3px 8px rgb(255 255 255 / 70%);
+  --shadow-neu-btn-hover: 2px 2px 5px rgb(183 183 164 / 20%), -2px -2px 5px rgb(255 255 255 / 60%);
 }
 
 /* Material Symbols - ensure they load and look sharp. */
@@ -221,7 +221,7 @@ pre,
   border-radius: 50%;
   background: var(--color-earthy-muted-green);
   border: 1px solid var(--color-earthy-dark-brown);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 15%);
   margin-top: -5px;
   cursor: pointer;
 }
@@ -239,7 +239,7 @@ pre,
   border-radius: 50%;
   background: var(--color-earthy-muted-green);
   border: 1px solid var(--color-earthy-dark-brown);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 15%);
   cursor: pointer;
 }
 
@@ -247,7 +247,7 @@ pre,
 .settings-panel-slide {
   transform: translateX(100%);
   transition: transform 0.3s ease-out;
-  box-shadow: -4px 0 24px rgba(0, 0, 0, 0.08);
+  box-shadow: -4px 0 24px rgb(0 0 0 / 8%);
 }
 .settings-panel-slide--open {
   transform: translateX(0);

--- a/src/lib/transcription/ModelManager.ts
+++ b/src/lib/transcription/ModelManager.ts
@@ -70,7 +70,7 @@ export class ModelManager {
    * Check if model is already cached (partial check)
    */
   async checkCache(): Promise<boolean> {
-    // In v2.0 we rely on parakeet.js/IndexedDB cache, but we can do a quick check
+    // We rely on parakeet.js/IndexedDB cache for full cache checks; this is a quick check.
     return this._isCached;
   }
 
@@ -276,8 +276,7 @@ export class ModelManager {
       });
 
       this._setProgress({ stage: 'import', progress: 20, message: 'Initialising parakeet.js...' });
-      const { ParakeetModel } = await import(
-        'parakeet.js');
+      const { ParakeetModel } = await import('parakeet.js');
 
       this._setProgress({ stage: 'compile', progress: 40, message: 'Compiling local model...' });
 

--- a/src/lib/transcription/SentenceBoundaryDetector.ts
+++ b/src/lib/transcription/SentenceBoundaryDetector.ts
@@ -8,7 +8,7 @@
  * Ported from legacy UI project/src/utils/SentenceBoundaryDetector.js to TypeScript.
  */
 
-import winkNLP from 'wink-nlp';
+import winkNLP, { type WinkMethods } from 'wink-nlp';
 import model from 'wink-eng-lite-web-model';
 
 /** A word object with text and timing information */
@@ -62,7 +62,7 @@ export interface SentenceBoundaryDetectorConfig {
 /** Detects sentence endings from ASR words using NLP with heuristic fallback. */
 export class SentenceBoundaryDetector {
     private config: SentenceBoundaryDetectorConfig;
-    private nlp: any | null = null;
+    private nlp: WinkMethods | null = null;
     private cache: Map<string, DetectedSentence[]> = new Map();
     private lastProcessedWordCount: number = 0;
     private lastSentenceEndings: SentenceEndingWord[] = [];

--- a/src/lib/transcription/WindowBuilder.ts
+++ b/src/lib/transcription/WindowBuilder.ts
@@ -59,6 +59,13 @@ export class WindowBuilder {
     private matureCursorFrame: number = 0;
     private firstSentenceReceived: boolean = false;
 
+    /**
+     * Create a window builder for cursor-aware transcription.
+     * @param ringBuffer Source audio ring buffer providing base/current frame offsets.
+     * @param vadBuffer Optional VAD buffer; when `null`, VAD boundary refinement is disabled.
+     * @param config Partial configuration that overrides built-in defaults.
+     * Duration fields are expressed in seconds.
+     */
     constructor(
         ringBuffer: IRingBuffer,
         vadBuffer: VADRingBuffer | null = null,
@@ -84,6 +91,8 @@ export class WindowBuilder {
 
     /**
      * Record the end frame of a fully finalized sentence.
+     * @param frameIdx Finalized sentence end frame in global frame coordinates.
+     * @returns `void`
      */
     markSentenceEnd(frameIdx: number): void {
         this.sentenceEnds.push(frameIdx);
@@ -105,6 +114,8 @@ export class WindowBuilder {
     /**
      * Advance the mature cursor to a finalized sentence boundary.
      * The mature cursor marks where transcription is considered stable.
+     * @param frameIdx Cursor target frame in global frame coordinates.
+     * @returns `void`
      */
     advanceMatureCursor(frameIdx: number): void {
         if (frameIdx > this.matureCursorFrame) {
@@ -127,6 +138,8 @@ export class WindowBuilder {
     /**
      * Advance the mature cursor using a time value (seconds).
      * Converts to frame offset based on sample rate.
+     * @param timeSec Cursor target time in seconds.
+     * @returns `void`
      */
     advanceMatureCursorByTime(timeSec: number): void {
         const frameIdx = Math.round(timeSec * this.config.sampleRate);
@@ -135,6 +148,7 @@ export class WindowBuilder {
 
     /**
      * Get current mature cursor position in frames.
+     * @returns Current mature cursor frame.
      */
     getMatureCursorFrame(): number {
         return this.matureCursorFrame;
@@ -142,6 +156,7 @@ export class WindowBuilder {
 
     /**
      * Get current mature cursor position in seconds.
+     * @returns Current mature cursor time in seconds.
      */
     getMatureCursorTime(): number {
         return this.matureCursorFrame / this.config.sampleRate;

--- a/src/lib/transcription/transcription.worker.ts
+++ b/src/lib/transcription/transcription.worker.ts
@@ -5,8 +5,8 @@
  * to prevent UI stuttering on the main thread.
  *
  * Supports both:
- * - v3 token-stream mode (LCSPTFAMerger, fixed-window)
- * - v4 utterance mode (UtteranceBasedMerger, cursor-based windowing)
+ * - pipeline v3 token-stream mode (LCSPTFAMerger, fixed-window)
+ * - pipeline v4 utterance mode (UtteranceBasedMerger, cursor-based windowing)
  */
 
 import { ParakeetModel, getParakeetModel } from 'parakeet.js';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -135,6 +135,8 @@ export interface TranscriptPanelProps {
 export interface WaveformProps {
   /** Normalized audio level in the range 0-1. */
   audioLevel: number;
+  /** Oscilloscope samples in the range -1..1. */
+  barLevels?: Float32Array;
   /** Whether recording is active. */
   isRecording: boolean;
 }

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -4,8 +4,9 @@
  * @returns Zero-padded clock string.
  */
 export function formatDuration(seconds: number): string {
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const s = seconds % 60;
+  const safeSeconds = Number.isFinite(seconds) ? Math.max(0, Math.floor(seconds)) : 0;
+  const h = Math.floor(safeSeconds / 3600);
+  const m = Math.floor((safeSeconds % 3600) / 60);
+  const s = safeSeconds % 60;
   return `${h > 0 ? h.toString().padStart(2, '0') + ':' : ''}${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
 }


### PR DESCRIPTION
Summary
Low-risk cleanup and consistency pass for low-hanging issues.

What changed
- CSS: converted legacy `rgba(...)` alpha values to modern `rgb(r g b / a%)` syntax.
- Waveform: removed unused `barCount` flow and aligned component props with shared `WaveformProps`.
- Sidebar: removed unused `audioLevel` prop from `SidebarProps`.
- Worker/docs comments: disambiguated pipeline v3/v4 wording and removed stale `v2.0` cache comment.
- ModelManager: normalized dynamic import formatting.
- Time util: hardened `formatDuration` for non-finite/negative/fractional input.
- ContextPanel: marked `onDeviceSelect` callback as internal API.
- SentenceBoundaryDetector: typed `nlp` as `WinkMethods` instead of `any`.
- WindowBuilder: added constructor and method `@param` / `@returns` JSDoc tags.

Validation
- `npm run build`
- `npm run test`

Linked issues
Closes #132
Closes #133
Closes #150
Closes #152
Closes #154
Closes #156
Closes #157
Closes #158
Closes #160
Closes #161