### PR TITLE
Performance: O(1) running sum in AudioEngine

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
+## 2025-05-18 - Running sums in high-frequency loops
+Learning: In performance-critical per-chunk processing loops like audio processing, using `.reduce()` for moving averages causes GC overhead and O(N) complexity per frame.
+Action: Replace `.reduce()` and related iteration methods with O(1) running sums using persistent properties (e.g. `energySum`) to minimize GC churn and CPU overhead per tick.
+
 ## 2026-02-18 - Optimized Circular Buffer Access
 Learning: Circular buffers in performance-critical hot paths (like audio visualization loops running at 60 fps) benefit significantly from a "shadow buffer" strategy. By mirroring the buffer content (writing to `i` and `i + size`), we enable contiguous linear reads of any window of size `size` without modulo arithmetic.
 Action: Apply this pattern to other fixed-size sliding window buffers in the audio pipeline if profiling shows they are bottlenecks.

--- a/src/lib/audio/AudioEngine.ts
+++ b/src/lib/audio/AudioEngine.ts
@@ -52,6 +52,7 @@ export class AudioEngine implements IAudioEngine {
 
     // SMA buffer for energy calculation
     private energyHistory: number[] = [];
+    private energyHistorySum: number = 0;
 
     // Last N energy values for bar visualizer (oldest first when read)
     private energyBarHistory: number[] = [];
@@ -557,10 +558,11 @@ export class AudioEngine implements IAudioEngine {
 
         // SMA Smoothing (matching legacy UI project logic)
         this.energyHistory.push(maxAbs);
+        this.energyHistorySum += maxAbs;
         if (this.energyHistory.length > 6) {
-            this.energyHistory.shift();
+            this.energyHistorySum -= this.energyHistory.shift()!;
         }
-        const energy = this.energyHistory.reduce((a: number, b: number) => a + b, 0) / this.energyHistory.length;
+        const energy = this.energyHistorySum / this.energyHistory.length;
 
         this.currentEnergy = energy;
         this.energyBarHistory.push(energy);


### PR DESCRIPTION
What changed:
Refactored the `reduce()` operation in `AudioEngine.handleAudioChunk` to use an `O(1)` running sum (`energyHistorySum`) for the SMA energy calculation. 

Why it was needed:
The `handleAudioChunk` method is a hot path processing high-frequency audio streams. Using `.reduce()` on every frame resulted in `O(N)` algorithmic complexity and introduced garbage collection churn from allocating callback functions.

Impact:
Eliminated high-frequency memory allocations and array iterations in the audio processing loop. Synthetic benchmark times showed macro performance matched original state, but fundamental CPU cycle count and GC pressure on the main thread is mathematically reduced.

How to verify:
Run the audio engine tests: `bun test src/lib/audio/energy-calculation.test.ts`
Run the audio engine visualization tests: `bun test src/lib/audio/AudioEngine.visualization.test.ts`

---
*PR created automatically by Jules for task [16629740528072009080](https://jules.google.com/task/16629740528072009080) started by @ysdede*

## Summary by Sourcery

Optimize audio energy smoothing by replacing per-frame reductions with a constant-time running sum in the AudioEngine hot path.

Enhancements:
- Use a running sum for SMA energy calculation in AudioEngine to eliminate per-chunk array reductions and reduce GC pressure.

Chores:
- Update the engineering log with guidance on using running sums instead of array reductions in high-frequency processing loops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added technical guidance for optimizing high-frequency data processing loops used in real-time audio systems.

* **Refactor**
  * Enhanced audio engine's energy calculation for improved responsiveness and reduced computational overhead during chunk processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->