### PR TITLE
Refactor `data` parameter in `TranscriptionWorkerClient.ts` to use explicit types instead of `any`

### DIFF
--- a/src/lib/transcription/TranscriptionWorkerClient.ts
+++ b/src/lib/transcription/TranscriptionWorkerClient.ts
@@ -99,6 +99,16 @@ export interface WorkerMessageMap {
     V4_FINALIZE_TIMEOUT: { payload: void; response: V4ProcessResult | null };
     V4_RESET: { payload: void; response: void };
 }
+
+/** Valid incoming messages from the worker */
+export type WorkerIncomingMessage =
+    | { type: 'MODEL_PROGRESS'; payload: ModelProgress; id?: number }
+    | { type: 'MODEL_STATE'; payload: ModelState; id?: number }
+    | { type: 'V3_CONFIRMED'; payload: { text: string; words: any[] }; id?: number }
+    | { type: 'V3_PENDING'; payload: { text: string; words: any[] }; id?: number }
+    | { type: 'ERROR'; payload: string; id?: number }
+    | { type: string; payload?: any; id: number };
+
 export class TranscriptionWorkerClient {
     private static readonly DISPOSED_ERROR_MESSAGE = 'TranscriptionWorkerClient disposed';
     private worker: Worker;
@@ -126,7 +136,7 @@ export class TranscriptionWorkerClient {
         };
     }
 
-    private handleMessage(data: any) {
+    private handleMessage(data: WorkerIncomingMessage) {
         const { type, payload, id } = data;
 
         // Handle promise resolutions


### PR DESCRIPTION
🎯 **What:** Typed the `data` parameter in `handleMessage` method of `TranscriptionWorkerClient.ts` to replace the unsafe `any` type with a discriminated union `WorkerIncomingMessage`.

💡 **Why:** This improves maintainability and code readability by providing a single source of truth for the structure of messages emitted by `transcription.worker.ts`, making the contract clearer and enabling better static analysis.

✅ **Verification:** Verified that `handleMessage` continues to work exactly as before, as no logic was changed. Compiled the project and ran unit tests (which previously lacked type safety for these messages) successfully.

✨ **Result:** Improved type safety and developer experience when interfacing with the transcription background worker without changing runtime behavior.

---
*PR created automatically by Jules for task [10979186477214833768](https://jules.google.com/task/10979186477214833768) started by @ysdede*

## Summary by Sourcery

Enhancements:
- Introduce a discriminated union type for incoming transcription worker messages and use it in the worker client message handler to replace the previous untyped parameter.