### PR TITLE
refactor: type TranscriptionService._streamer property

### DIFF
--- a/src/lib/transcription/TranscriptionService.ts
+++ b/src/lib/transcription/TranscriptionService.ts
@@ -12,11 +12,12 @@ import type {
   TranscriptionWord
 } from './types';
 import { ModelManager } from './ModelManager';
+import type { StatefulStreamingTranscriber } from 'parakeet.js';
 
 /** High-level transcription facade for streaming chunks and finalized segments. */
 export class TranscriptionService {
   private _modelManager: ModelManager;
-  private _streamer: any = null; // StatefulStreamingTranscriber
+  private _streamer: StatefulStreamingTranscriber | null = null;
   private _config: TranscriptionServiceConfig;
   private _callbacks: TranscriptionCallbacks = {};
   private _isProcessing: boolean = false;


### PR DESCRIPTION
🎯 **What:** Replaced the `any` type on the `_streamer` property with `StatefulStreamingTranscriber | null` by importing the type from `parakeet.js`.
💡 **Why:** This directly addresses the code health issue to replace the loose `any` typing. It improves codebase readability and maintainability by explicitly declaring the expected type interface for the streaming transcriber instance, enabling IDE support and type-checking.
✅ **Verification:** Verified via TypeScript's type-checker `tsc --noEmit` which completed successfully and by running the application's full Vitest suite to ensure no runtime regressions were introduced.
✨ **Result:** Improved static analysis and stronger, explicit type safety for `TranscriptionService`.

---
*PR created automatically by Jules for task [14030105358023450048](https://jules.google.com/task/14030105358023450048) started by @ysdede*

## Summary by Sourcery

Enhancements:
- Replace the TranscriptionService _streamer any-typed field with a precise StatefulStreamingTranscriber | null type imported from parakeet.js.