### PR TITLE
Strongly type the message in worker respond function

### DIFF
--- a/src/lib/vad/tenvad.worker.ts
+++ b/src/lib/vad/tenvad.worker.ts
@@ -11,7 +11,7 @@
  * the AudioWorklet) and the worker handles the hop alignment internally.
  */
 
-import type { TenVADRequest, TenVADResult } from '../buffer/types';
+import type { TenVADRequest, TenVADResult, TenVADResponse } from '../buffer/types';
 
 // ---- TEN-VAD Module Interface ----
 
@@ -217,7 +217,7 @@ function handleProcess(samples: Float32Array, globalSampleOffset: number): void 
             processingTimeMs: performance.now() - startTime,
         };
 
-        (self as any).postMessage(
+        respond(
             { type: 'RESULT', payload: result },
             [trimmedProbs.buffer, trimmedFlags.buffer]
         );
@@ -258,7 +258,7 @@ function handleDispose(id: number): void {
     respond({ type: 'DISPOSE', id, payload: { success: true } });
 }
 
-function respond(msg: any, transfers?: Transferable[]): void {
+function respond(msg: TenVADResponse, transfers?: Transferable[]): void {
     try {
         if (transfers) {
             (self as any).postMessage(msg, transfers);


### PR DESCRIPTION
🎯 **What:** The `msg` parameter in the `respond` function within `src/lib/vad/tenvad.worker.ts` was typed as `any`. It has now been strongly typed using the existing `TenVADResponse` interface. Additionally, a raw `postMessage` call was refactored to use the updated `respond` helper.

💡 **Why:** This change enforces type safety across inter-process communication (IPC) for the TEN-VAD worker, ensuring that all emitted messages conform to a single, explicit contract (`TenVADResponse`). This improves maintainability and helps catch payload structure errors at compile time.

✅ **Verification:** Verified by running the worker integration test suite via `npm run test src/lib/vad/tenvad.worker.test.ts`. The worker loaded successfully, responded to initialization appropriately, and processed results with the correct output shapes. No regressions in behavior were observed.

✨ **Result:** Improved type safety and standardization of worker messaging without altering runtime behavior.

---
*PR created automatically by Jules for task [14187786017441024959](https://jules.google.com/task/14187786017441024959) started by @ysdede*

## Summary by Sourcery

Strengthen typing and standardize message handling in the TEN-VAD worker.

Enhancements:
- Strongly type the TEN-VAD worker respond helper using the TenVADResponse interface to enforce a consistent message contract.
- Refactor a direct worker postMessage call to use the shared respond helper for result messages.