### PR TITLE
[Code Health] Define types for ONNX Runtime session and state

### DIFF
--- a/src/lib/vad/SileroVAD.ts
+++ b/src/lib/vad/SileroVAD.ts
@@ -1,7 +1,8 @@
 import type { SileroVADConfig, SileroVADResult } from './types';
+import type { InferenceSession, Tensor } from 'onnxruntime-web';
 
 // Use the globally-exposed ort from parakeet.js / onnxruntime-web
-declare const ort: any;
+declare const ort: typeof import('onnxruntime-web');
 
 /**
  * Silero VAD ONNX model runner for browser-side voice activity detection.
@@ -17,13 +18,13 @@ declare const ort: any;
  */
 export class SileroVAD {
     private config: SileroVADConfig;
-    private session: any | null = null;
+    private session: InferenceSession | null = null;
     private initialized: boolean = false;
 
     // Internal LSTM state tensors (persisted across calls)
-    private stateH: any | null = null;
-    private stateC: any | null = null;
-    private srTensor: any | null = null;
+    private stateH: Tensor | null = null;
+    private stateC: Tensor | null = null;
+    private srTensor: Tensor | null = null;
 
     // Silero model constants
     // For 16kHz: hop_size=512 (32ms), context_size=64
@@ -137,7 +138,7 @@ export class SileroVAD {
         const probability = outputData[0];
 
         // Update persistent state
-        this.stateH = results.stateN;
+        this.stateH = results.stateN as Tensor;
 
         const isSpeech = probability >= this.config.threshold;
 


### PR DESCRIPTION
🎯 **What:** Replaced the use of `any` types for the ONNX Runtime session and state variables with their strict types (`InferenceSession` and `Tensor`) from `onnxruntime-web`.
💡 **Why:** This improves the maintainability and type safety of `SileroVAD.ts`. By leveraging the actual typings instead of `any`, future changes or updates are properly protected by TypeScript compilation checks, reducing the risk of runtime errors.
✅ **Verification:** Verified that `pnpm test` runs cleanly and successfully, and that no unrequested dependencies were added to `package.json`. The TypeScript compiler (`tsc`) was also run and confirmed that `ort` typings are matched correctly.
✨ **Result:** A more readable, predictable, and strongly-typed file with identical runtime behavior.

---
*PR created automatically by Jules for task [7812390940331716981](https://jules.google.com/task/7812390940331716981) started by @ysdede*

## Summary by Sourcery

Enhancements:
- Replace loosely-typed ONNX Runtime session and state properties with strict InferenceSession and Tensor types from onnxruntime-web to improve type safety.