### PR TITLE
fix: avoid using any for MediaQueryListEvent return type

### DIFF
--- a/src/components/LayeredBufferVisualizer.tsx
+++ b/src/components/LayeredBufferVisualizer.tsx
@@ -91,7 +91,7 @@ export const LayeredBufferVisualizer: Component<LayeredBufferVisualizerProps> = 
     let cachedDpr = window.devicePixelRatio || 1;
     let resizeObserver: ResizeObserver | null = null;
     let dprMediaQuery: MediaQueryList | null = null;
-    let dprChangeHandler: ((this: MediaQueryList, ev: MediaQueryListEvent) => any) | null = null;
+    let dprChangeHandler: ((this: MediaQueryList, ev: MediaQueryListEvent) => void) | null = null;
 
     /** Recompute physical canvas dimensions from cached logical size + DPR. */
     const updateCanvasDimensions = (logicalW: number, logicalH: number) => {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the use of `any` as the return type for the `MediaQueryListEvent` handler `dprChangeHandler` in `src/components/LayeredBufferVisualizer.tsx`.
💡 **Why:** Replacing `any` with `void` improves code health by tightening the TypeScript types, accurately reflecting that DOM event handlers do not utilize return values, and preventing potential accidental misuse.
✅ **Verification:** Verified by running the test suite (`bun test`) to ensure no regressions were introduced. Additionally, performed frontend verification using a Playwright script to confirm that the UI compiles and runs smoothly, preserving existing behavior.
✨ **Result:** A safer, more strictly typed event handler signature with no change to runtime functionality.

---
*PR created automatically by Jules for task [9232382638077268366](https://jules.google.com/task/9232382638077268366) started by @ysdede*

## Summary by Sourcery

Enhancements:
- Refine the MediaQueryList event handler type in LayeredBufferVisualizer to return void instead of any for stricter type safety.