### PR TITLE
Use standard Window interface for idle callbacks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -485,7 +485,7 @@ const App: Component = () => {
 
   const cancelWasmWarmupSchedule = () => {
     if (warmupIdleHandle !== null && typeof window !== 'undefined' && 'cancelIdleCallback' in window) {
-      (window as any).cancelIdleCallback(warmupIdleHandle);
+      window.cancelIdleCallback(warmupIdleHandle);
       warmupIdleHandle = null;
     }
     if (warmupTimeoutHandle !== undefined) {
@@ -518,7 +518,7 @@ const App: Component = () => {
   const scheduleWasmWarmup = () => {
     cancelWasmWarmupSchedule();
     if (typeof window !== 'undefined' && 'requestIdleCallback' in window) {
-      warmupIdleHandle = (window as any).requestIdleCallback(() => {
+      warmupIdleHandle = window.requestIdleCallback(() => {
         warmupIdleHandle = null;
         void runWasmWarmup();
       }, { timeout: 2500 });

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,3 +4,14 @@ declare const __KEET_VERSION__: string;
 declare const __PARAKEET_VERSION__: string;
 declare const __PARAKEET_SOURCE__: string;
 declare const __ONNXRUNTIME_VERSION__: string;
+
+interface Window {
+  requestIdleCallback(
+    callback: (deadline: {
+      readonly didTimeout: boolean;
+      timeRemaining(): number;
+    }) => void,
+    options?: { timeout: number }
+  ): number;
+  cancelIdleCallback(handle: number): void;
+}


### PR DESCRIPTION
🎯 **What:** Extended the global `Window` interface to include proper TypeScript definitions for `requestIdleCallback` and `cancelIdleCallback` instead of casting `window` to `any`.
💡 **Why:** Reduces unsafe `any` usages and correctly utilizes native browser APIs, improving type safety and readability.
✅ **Verification:** Ran test suite and production build step.
✨ **Result:** Safe typing applied to idle callbacks.

---
*PR created automatically by Jules for task [5515221070947143723](https://jules.google.com/task/5515221070947143723) started by @ysdede*

## Summary by Sourcery

Strengthen typing around browser idle callbacks and remove unsafe window casts.

Enhancements:
- Extend the global Window interface with typed requestIdleCallback and cancelIdleCallback definitions.
- Replace any-casted window idle callback usage in the WASM warmup scheduling logic with the now-typed Window methods.