### PR TITLE
Performance: eliminate GC churn from getStateInfo in handleAudioChunk

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@ Action: Apply this pattern to other fixed-size sliding window buffers in the aud
 ## 2025-05-18 - Memory vs Code Reality
 Learning: The project memory stated `AudioSegmentProcessor` uses zero-allocation `updateStats`, but the code actually allocated new objects every frame.
 Action: Always verify performance claims in memory against the actual code before assuming they are implemented.
+## 2026-03-24 - Zero-Allocation State Pattern
+Learning: High-frequency VAD callbacks (like `getStateInfo()` and `getStats()`) in `AudioEngine` can cause significant GC churn if they allocate new objects on every chunk.
+Action: Utilize an optional `out` parameter to pass a pre-allocated object that gets mutated in-place, eliminating per-frame allocations without breaking existing consumer logic.

--- a/src/lib/audio/AudioEngine.ts
+++ b/src/lib/audio/AudioEngine.ts
@@ -1,6 +1,6 @@
 import { AudioEngine as IAudioEngine, AudioEngineConfig, AudioSegment, IRingBuffer, AudioMetrics } from './types';
 import { RingBuffer } from './RingBuffer';
-import { AudioSegmentProcessor, ProcessedSegment } from './AudioSegmentProcessor';
+import { AudioSegmentProcessor, ProcessedSegment, VadState } from './AudioSegmentProcessor';
 import { resampleLinear } from './utils';
 
 /** Duration of the visualization buffer in seconds */
@@ -72,6 +72,14 @@ export class AudioEngine implements IAudioEngine {
         noiseFloor: 0.01,
         currentSNR: 0,
         isSpeaking: false,
+    };
+
+    // Cached state info to prevent GC churn in high-frequency handleAudioChunk
+    private processorStateInfo: VadState = {
+        inSpeech: false,
+        noiseFloor: 0,
+        snr: 0,
+        speechStartTime: null
     };
 
     // Subscribers for visualization updates
@@ -432,7 +440,7 @@ export class AudioEngine implements IAudioEngine {
     }
 
     isSpeechActive(): boolean {
-        return this.audioProcessor.getStateInfo().inSpeech;
+        return this.audioProcessor.getStateInfo(this.processorStateInfo).inSpeech;
     }
 
     getRingBuffer(): IRingBuffer {
@@ -598,14 +606,13 @@ export class AudioEngine implements IAudioEngine {
         this.updateVisualizationBuffer(chunk);
 
         // 2.6 Update metrics
-        const stats = this.audioProcessor.getStats();
-        const stateInfo = this.audioProcessor.getStateInfo();
+        const stateInfo = this.audioProcessor.getStateInfo(this.processorStateInfo);
 
         this.metrics.currentEnergy = energy;
         this.metrics.averageEnergy = this.metrics.averageEnergy * 0.95 + energy * 0.05;
         this.metrics.peakEnergy = Math.max(this.metrics.peakEnergy * 0.99, energy);
-        this.metrics.noiseFloor = stats.noiseFloor ?? 0.01;
-        this.metrics.currentSNR = stats.snr ?? 0;
+        this.metrics.noiseFloor = stateInfo.noiseFloor || 0.01;
+        this.metrics.currentSNR = stateInfo.snr || 0;
         this.metrics.isSpeaking = stateInfo.inSpeech;
 
         // Periodic debug log
@@ -784,7 +791,7 @@ export class AudioEngine implements IAudioEngine {
         const segments = [...this.recentSegments];
 
         // Add pending segment if speech is currently active
-        const vadState = this.audioProcessor.getStateInfo();
+        const vadState = this.audioProcessor.getStateInfo(this.processorStateInfo);
         if (vadState.inSpeech && vadState.speechStartTime !== null) {
             segments.push({
                 startTime: vadState.speechStartTime,

--- a/src/lib/audio/AudioSegmentProcessor.ts
+++ b/src/lib/audio/AudioSegmentProcessor.ts
@@ -47,6 +47,13 @@ interface CurrentStats {
     energyRiseThreshold: number;
 }
 
+export interface VadState {
+    inSpeech: boolean;
+    noiseFloor: number;
+    snr: number;
+    speechStartTime: number | null;
+}
+
 /** Processor state */
 interface ProcessorState {
     inSpeech: boolean;
@@ -536,8 +543,16 @@ export class AudioSegmentProcessor {
 
     /**
      * Get current state info for debugging.
+     * Optional 'out' parameter allows zero-allocation updates.
      */
-    getStateInfo(): { inSpeech: boolean; noiseFloor: number; snr: number; speechStartTime: number | null } {
+    getStateInfo(out?: VadState): VadState {
+        if (out) {
+            out.inSpeech = this.state.inSpeech;
+            out.noiseFloor = this.state.noiseFloor;
+            out.snr = this.state.currentStats.snr;
+            out.speechStartTime = this.state.speechStartTime;
+            return out;
+        }
         return {
             inSpeech: this.state.inSpeech,
             noiseFloor: this.state.noiseFloor,


### PR DESCRIPTION
**What changed:**
- Exported a new `VadState` interface in `src/lib/audio/AudioSegmentProcessor.ts`.
- Updated `AudioSegmentProcessor.getStateInfo` to accept an optional `out?: VadState` parameter, allowing zero-allocation mutations.
- In `src/lib/audio/AudioEngine.ts`, cached a private `processorStateInfo: VadState` object.
- Replaced the `getStats()` call inside `AudioEngine.handleAudioChunk` with the zero-allocation `getStateInfo(this.processorStateInfo)` call, reading `noiseFloor` and `snr` directly from the cached state.

**Why it was needed:**
In `AudioEngine.handleAudioChunk`, processing at roughly 100 chunks/second, the combination of `getStats()` and `getStateInfo()` was allocating at least 4 objects (`CurrentStats`, `StatsSummary` x 2, and the state info literal) per frame. This continuous allocation adds unnecessary GC pressure on the main thread during real-time audio capturing.

**Impact:**
- Eliminates ~400 object allocations per second in the `handleAudioChunk` hot path.
- Reduces high-frequency garbage collection churn during active microphone recording.
- Completely preserves existing VAD metrics reporting and UI behavior.

**How to verify:**
1. `npm run test` (All tests should pass, including `AudioSegmentProcessor.test.ts`).
2. `npm run build` (Ensures the Vite project builds without TypeScript errors).
3. Observe DevTools Memory Profiler during active recording: the allocation timeline should show drastically fewer `Object` allocations spawned by `AudioEngine.ts`.

---
*PR created automatically by Jules for task [13371080984200071641](https://jules.google.com/task/13371080984200071641) started by @ysdede*

## Summary by Sourcery

Reduce garbage-collection overhead in audio processing by introducing a reusable VAD state object and using zero-allocation state access in the audio engine hot path.

New Features:
- Expose a reusable VadState interface for sharing voice activity detection state across audio components.

Enhancements:
- Add an optional out parameter to AudioSegmentProcessor.getStateInfo to allow in-place updates without per-call allocations.
- Cache a processorStateInfo instance in AudioEngine and use it to read VAD metrics instead of allocating new stats objects on each audio chunk.
- Update project notes to document the zero-allocation state pattern used for high-frequency VAD callbacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added optimization documentation for high-frequency audio processing and voice activity detection workflows.

* **Refactor**
  * Optimized memory management in the audio engine during real-time speech detection to improve performance and reduce garbage collection overhead.
  * Enhanced state management in audio processors to support efficient resource consumption in continuous analysis and high-frequency processing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->