### PR TITLE
Performance: Optimize VAD segment energy tracking to zero-allocation running sum

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@ Action: Apply this pattern to other fixed-size sliding window buffers in the aud
 ## 2025-05-18 - Memory vs Code Reality
 Learning: The project memory stated `AudioSegmentProcessor` uses zero-allocation `updateStats`, but the code actually allocated new objects every frame.
 Action: Always verify performance claims in memory against the actual code before assuming they are implemented.
+
+## 2026-02-18 - O(1) Running Sum for High-Frequency VAD Energy
+Learning: `AudioSegmentProcessor` was accumulating energy values per-chunk into arrays (`speechEnergies` and `silenceEnergies`), then calculating averages using `.reduce()`. This array manipulation inside an 80ms hot-path created continuous memory allocations and GC pressure.
+Action: In streaming loops, use running totals (e.g. `sum` and `count` properties) rather than storing arrays of primitive values for average calculations. This makes the computation O(1) and zero-allocation.

--- a/src/lib/audio/AudioSegmentProcessor.ts
+++ b/src/lib/audio/AudioSegmentProcessor.ts
@@ -54,8 +54,8 @@ interface ProcessorState {
     silenceStartTime: number | null;
     silenceCounter: number;
     recentChunks: ChunkInfo[];
-    speechEnergies: number[];
-    silenceEnergies: number[];
+    speechEnergySum: number;
+    speechEnergyCount: number;
     speechStats: SegmentStats[];
     silenceStats: SegmentStats[];
     cachedSpeechSummary: StatsSummary | null;
@@ -249,13 +249,14 @@ export class AudioSegmentProcessor {
             // Check if we should allow some silence within speech
             if (silenceDuration < this.options.maxSilenceWithinSpeech) {
                 // Not yet enough silence to consider it a break
-                this.state.speechEnergies.push(energy);
+                this.state.speechEnergySum += energy;
+                this.state.speechEnergyCount++;
             } else if (isConfirmedSilence) {
                 // Confirmed silence - end speech segment
                 if (this.state.speechStartTime !== null) {
                     const speechDuration = currentTime - this.state.speechStartTime;
-                    const avgEnergy = this.state.speechEnergies.length > 0
-                        ? this.state.speechEnergies.reduce((a, b) => a + b, 0) / this.state.speechEnergies.length
+                    const avgEnergy = this.state.speechEnergyCount > 0
+                        ? this.state.speechEnergySum / this.state.speechEnergyCount
                         : 0;
 
                     this.recordSpeechStat({
@@ -274,15 +275,15 @@ export class AudioSegmentProcessor {
 
                 this.startSilence(currentTime);
             } else {
-                // Accumulate silence energies while deciding
-                this.state.silenceEnergies.push(energy);
+                // We are deciding whether it's silence or speech, just do nothing
             }
         } else {
             // Continue in current state
             if (this.state.inSpeech) {
-                this.state.speechEnergies.push(energy);
+                this.state.speechEnergySum += energy;
+                this.state.speechEnergyCount++;
             } else {
-                this.state.silenceEnergies.push(energy);
+                // Silence, do nothing with energies
             }
         }
 
@@ -332,7 +333,8 @@ export class AudioSegmentProcessor {
         this.state.inSpeech = true;
         this.state.speechStartTime = time;
         this.state.silenceCounter = 0;
-        this.state.speechEnergies = [energy];
+        this.state.speechEnergySum = energy;
+        this.state.speechEnergyCount = 1;
         this.state.silenceStartTime = null;
         this.state.silenceDuration = 0;
 
@@ -353,7 +355,6 @@ export class AudioSegmentProcessor {
         this.state.silenceStartTime = time;
         this.state.speechStartTime = null;
         this.state.silenceCounter = 0;
-        this.state.silenceEnergies = [];
         this.state.silenceDuration = 0.001; // Avoid division by zero
 
         this.log('Silence state started', {
@@ -556,8 +557,8 @@ export class AudioSegmentProcessor {
             silenceStartTime: null,
             silenceCounter: 0,
             recentChunks: [],
-            speechEnergies: [],
-            silenceEnergies: [],
+            speechEnergySum: 0,
+            speechEnergyCount: 0,
             speechStats: [],
             silenceStats: [],
             cachedSpeechSummary: null,


### PR DESCRIPTION
### What changed
Replaced `speechEnergies` and `silenceEnergies` arrays in `AudioSegmentProcessor` with a running `speechEnergySum` and `speechEnergyCount`.

### Why it was needed (bottleneck evidence)
The `processAudioData` function runs very frequently (every ~80ms per 16kHz chunk). It was pushing `energy` floats into arrays (`speechEnergies` and `silenceEnergies`) and later calling `.reduce()` to calculate the average. This caused unnecessary object allocations and array iterations, contributing to main-thread GC churn during active speech.

### Impact
- Eliminates one array `.push()` per audio chunk.
- Removes an O(N) array iteration (`.reduce()`) to calculate the average energy when a segment finalizes.
- Drops an unused state array (`silenceEnergies`).
- Results in zero-allocation energy tracking inside the VAD processor loop.

### How to verify
1. Run `npx vitest run src/lib/audio/AudioSegmentProcessor.test.ts` to confirm VAD functionality remains identical.
2. In a performance profile (e.g. Chrome DevTools), observe reduced minor GC events during continuous speech input.

---
*PR created automatically by Jules for task [10749343366007178863](https://jules.google.com/task/10749343366007178863) started by @ysdede*

## Summary by Sourcery

Optimize VAD energy tracking in AudioSegmentProcessor to avoid per-chunk allocations and O(N) averaging in the hot path.

Enhancements:
- Replace per-chunk speech energy arrays with running sum and count to compute average energy in O(1).
- Remove unused silence energy tracking to simplify VAD processor state and reduce memory usage.
- Update project notes to capture the running-sum pattern for high-frequency VAD energy computation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Enhanced audio processing efficiency through optimized energy calculation, reducing memory overhead in streaming audio scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->