### PR TITLE
Performance: reduce GC and CPU overhead in AudioSegmentProcessor

### DIFF
--- a/src/lib/audio/AudioSegmentProcessor.ts
+++ b/src/lib/audio/AudioSegmentProcessor.ts
@@ -54,8 +54,8 @@ interface ProcessorState {
     silenceStartTime: number | null;
     silenceCounter: number;
     recentChunks: ChunkInfo[];
-    speechEnergies: number[];
-    silenceEnergies: number[];
+    speechEnergySum: number;
+    speechEnergyCount: number;
     speechStats: SegmentStats[];
     silenceStats: SegmentStats[];
     cachedSpeechSummary: StatsSummary | null;
@@ -249,13 +249,14 @@ export class AudioSegmentProcessor {
             // Check if we should allow some silence within speech
             if (silenceDuration < this.options.maxSilenceWithinSpeech) {
                 // Not yet enough silence to consider it a break
-                this.state.speechEnergies.push(energy);
+                this.state.speechEnergySum += energy;
+                this.state.speechEnergyCount++;
             } else if (isConfirmedSilence) {
                 // Confirmed silence - end speech segment
                 if (this.state.speechStartTime !== null) {
                     const speechDuration = currentTime - this.state.speechStartTime;
-                    const avgEnergy = this.state.speechEnergies.length > 0
-                        ? this.state.speechEnergies.reduce((a, b) => a + b, 0) / this.state.speechEnergies.length
+                    const avgEnergy = this.state.speechEnergyCount > 0
+                        ? this.state.speechEnergySum / this.state.speechEnergyCount
                         : 0;
 
                     this.recordSpeechStat({
@@ -273,16 +274,12 @@ export class AudioSegmentProcessor {
                 }
 
                 this.startSilence(currentTime);
-            } else {
-                // Accumulate silence energies while deciding
-                this.state.silenceEnergies.push(energy);
             }
         } else {
             // Continue in current state
             if (this.state.inSpeech) {
-                this.state.speechEnergies.push(energy);
-            } else {
-                this.state.silenceEnergies.push(energy);
+                this.state.speechEnergySum += energy;
+                this.state.speechEnergyCount++;
             }
         }
 
@@ -332,7 +329,8 @@ export class AudioSegmentProcessor {
         this.state.inSpeech = true;
         this.state.speechStartTime = time;
         this.state.silenceCounter = 0;
-        this.state.speechEnergies = [energy];
+        this.state.speechEnergySum = energy;
+        this.state.speechEnergyCount = 1;
         this.state.silenceStartTime = null;
         this.state.silenceDuration = 0;
 
@@ -353,7 +351,6 @@ export class AudioSegmentProcessor {
         this.state.silenceStartTime = time;
         this.state.speechStartTime = null;
         this.state.silenceCounter = 0;
-        this.state.silenceEnergies = [];
         this.state.silenceDuration = 0.001; // Avoid division by zero
 
         this.log('Silence state started', {
@@ -556,8 +553,8 @@ export class AudioSegmentProcessor {
             silenceStartTime: null,
             silenceCounter: 0,
             recentChunks: [],
-            speechEnergies: [],
-            silenceEnergies: [],
+            speechEnergySum: 0,
+            speechEnergyCount: 0,
             speechStats: [],
             silenceStats: [],
             cachedSpeechSummary: null,


### PR DESCRIPTION
What changed:
Replaced the `speechEnergies` and `silenceEnergies` arrays in `AudioSegmentProcessor.ts` with O(1) running scalar sum and count variables (`speechEnergySum`, `speechEnergyCount`).

Why it was needed (bottleneck evidence):
During high-frequency audio chunk processing loops, dynamically pushing to arrays (`this.state.speechEnergies.push(energy)`) and using `.reduce` (`this.state.speechEnergies.reduce((a, b) => a + b, 0) / this.state.speechEnergies.length`) introduces unnecessary CPU and Garbage Collection (GC) overhead. `silenceEnergies` was also being appended to but never actually read or used for any calculations.

Impact:
Eliminates intermediate array allocations and `.reduce()` iteration per segment, providing a small but measurable reduction in memory allocations and CPU overhead in the VAD audio loop.

How to verify:
Run the test suite using `npm run test` and observe that `AudioSegmentProcessor` behaviors remain unchanged while no regressions occur. Build using `bun run build`.

---
*PR created automatically by Jules for task [16316793501974944230](https://jules.google.com/task/16316793501974944230) started by @ysdede*

## Summary by Sourcery

Optimize AudioSegmentProcessor speech energy tracking to reduce CPU and GC overhead during VAD processing loops.

Enhancements:
- Replace speech energy array accumulation with running sum and count to compute average speech energy in O(1) per chunk.
- Remove unused silence energy tracking and related state to simplify processor state and avoid unnecessary allocations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal audio segment processor's energy aggregation calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->