### PR TITLE
feat: sweep small and medium issue fixes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -209,6 +209,7 @@ const Header: Component<{
 const WIDGET_MAX_W = 672;
 const WIDGET_MIN_H = 80;
 const SETTINGS_SAVE_DEBOUNCE_MS = 150;
+const PREVIEW_UPDATE_INTERVAL_MS = 50;
 
 const getDefaultWidgetPosition = (): { x: number; y: number } => {
   const width = typeof window !== 'undefined' ? window.innerWidth : 800;
@@ -315,6 +316,7 @@ const App: Component = () => {
   let removeWarmupGestureListeners: (() => void) | null = null;
   let warmupCancelled = false;
   let warmupStarted = false;
+  let lastPreviewUpdateAt = 0;
 
   const isRecording = () => appStore.recordingState() === 'recording';
   const isModelReady = () => appStore.modelState() === 'ready';
@@ -424,7 +426,7 @@ const App: Component = () => {
       }
     };
     document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
+    onCleanup(() => document.removeEventListener('keydown', handler));
   });
 
   createEffect(() => {
@@ -913,6 +915,7 @@ const App: Component = () => {
       appStore.stopRecording();
       appStore.setAudioLevel(0);
       appStore.setBarLevels(new Float32Array(0));
+      lastPreviewUpdateAt = 0;
 
       try {
         audioEngine?.stop();
@@ -1204,7 +1207,12 @@ const App: Component = () => {
           if (appStore.transcriptionMode() !== 'v4-utterance') {
             appStore.setIsSpeechDetected(audioEngine?.isSpeechActive() ?? false);
           }
-          appStore.setBarLevels(audioEngine!.getBarLevels());
+          const pageVisible = typeof document === 'undefined' || document.visibilityState === 'visible';
+          const now = performance.now();
+          if (pageVisible && now - lastPreviewUpdateAt >= PREVIEW_UPDATE_INTERVAL_MS) {
+            lastPreviewUpdateAt = now;
+            appStore.setBarLevels(audioEngine!.getBarLevels());
+          }
         });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -1350,6 +1358,9 @@ const App: Component = () => {
             }}
             onMouseEnter={cancelPanelClose}
             onMouseLeave={panelMouseLeave}
+            role="region"
+            aria-label="Quick settings panel"
+            aria-hidden={!showContextPanel()}
           >
             <div class="max-h-[70vh] min-h-0 flex flex-col overflow-y-auto custom-scrollbar">
               <SettingsContent
@@ -1384,6 +1395,23 @@ const App: Component = () => {
             <div class="flex-1 min-w-0 flex flex-col justify-center gap-1">
               <div class="h-8 flex items-center justify-center gap-1 overflow-hidden opacity-80 abstract-wave">
                 <CompactWaveform audioLevel={appStore.audioLevel()} barLevels={appStore.barLevels()} isRecording={isRecording()} />
+              </div>
+              <div class="flex items-center gap-2 px-1">
+                <span class="text-[10px] uppercase tracking-wider text-[var(--color-earthy-soft-brown)] font-bold">Input</span>
+                <div class="relative flex-1 h-1.5 rounded-full overflow-hidden bg-[var(--color-earthy-sage)]/25">
+                  <div
+                    class="absolute top-0 bottom-0 w-px bg-[var(--color-earthy-coral)] z-10"
+                    style={{ left: `${Math.min(100, appStore.energyThreshold() * 100)}%` }}
+                    title="Energy threshold"
+                  />
+                  <div
+                    class={`h-full transition-all duration-75 ${appStore.audioLevel() > appStore.energyThreshold() ? 'bg-[var(--color-earthy-coral)]' : 'bg-[var(--color-earthy-muted-green)]'}`}
+                    style={{ width: `${Math.min(100, appStore.audioLevel() * 100)}%` }}
+                  />
+                </div>
+                <span class={`text-[10px] font-mono tabular-nums ${appStore.audioLevel() > appStore.energyThreshold() ? 'text-[var(--color-earthy-coral)]' : 'text-[var(--color-earthy-soft-brown)]'}`}>
+                  {(appStore.audioLevel() * 100).toFixed(0)}%
+                </span>
               </div>
               <Show when={appStore.modelState() === 'loading'}>
                 <div class="flex items-center gap-2 px-1">

--- a/src/components/BufferVisualizer.tsx
+++ b/src/components/BufferVisualizer.tsx
@@ -4,8 +4,9 @@
  * Ported from legacy UI project (Svelte) to SolidJS.
  */
 
-import { Component, createSignal, onMount, onCleanup, createEffect } from 'solid-js';
+import { Component, createEffect, createSignal, onCleanup, onMount } from 'solid-js';
 import type { AudioEngine, AudioMetrics } from '../lib/audio';
+import { usePageVisible } from '../utils/usePageVisible';
 
 interface BufferVisualizerProps {
   /** AudioEngine instance for subscribing to visualization updates */
@@ -24,365 +25,300 @@ interface BufferVisualizerProps {
 
 /** Real-time waveform and segment visualizer backed by `AudioEngine` snapshots. */
 export const BufferVisualizer: Component<BufferVisualizerProps> = (props) => {
-  // Canvas element ref
   let canvasRef: HTMLCanvasElement | undefined;
   let ctx: CanvasRenderingContext2D | null = null;
   let parentRef: HTMLDivElement | undefined;
 
-  // State
   const [isDarkSignal, setIsDarkSignal] = createSignal(false);
-  const [canvasWidth, setCanvasWidth] = createSignal(0);
-  // Use { equals: false } because we reuse the same buffer reference for performance
-  const [waveformData, setWaveformData] = createSignal<Float32Array>(new Float32Array(0), { equals: false });
-  const [metrics, setMetrics] = createSignal<AudioMetrics>({
+  const pageVisible = usePageVisible();
+
+  let canvasWidth = 0;
+  let waveformData = new Float32Array(0);
+  let currentMetrics: AudioMetrics = {
     currentEnergy: 0,
     averageEnergy: 0,
     peakEnergy: 0,
     noiseFloor: 0.01,
     currentSNR: 0,
     isSpeaking: false,
-  });
-  const [segments, setSegments] = createSignal<Array<{ startTime: number; endTime: number; isProcessed: boolean }>>([]);
-  // Track the end time of the current waveform snapshot for strict synchronization
-  const [bufferEndTime, setBufferEndTime] = createSignal(0);
+  };
+  let currentSegments: Array<{ startTime: number; endTime: number; isProcessed: boolean }> = [];
+  let currentBufferEndTime = 0;
 
   const height = () => props.height ?? 80;
   const showThreshold = () => props.showThreshold ?? true;
   const snrThreshold = () => props.snrThreshold ?? 6.0;
   const showTimeMarkers = () => props.showTimeMarkers ?? true;
   const visible = () => props.visible ?? true;
+  const isActive = () => visible() && pageVisible();
 
   let rafId: number | undefined;
-  let timeoutId: number | undefined;
   let resizeObserver: ResizeObserver | null = null;
   let needsRedraw = true;
   let lastDrawTime = 0;
   const DRAW_INTERVAL_MS = 33;
 
-  const scheduleRaf = () => {
-    if (timeoutId !== undefined) {
-      clearTimeout(timeoutId);
-      timeoutId = undefined;
-    }
-    rafId = requestAnimationFrame(drawLoop);
-  };
-
-  const scheduleTimeout = () => {
+  const cancelLoop = () => {
     if (rafId !== undefined) {
       cancelAnimationFrame(rafId);
       rafId = undefined;
     }
-    timeoutId = window.setTimeout(drawLoop, 100);
   };
 
-  // Draw function
   const draw = () => {
     if (!ctx || !canvasRef) return;
 
     const width = canvasRef.width;
     const canvasHeight = canvasRef.height;
     const centerY = canvasHeight / 2;
-    const data = waveformData();
-    const currentMetrics = metrics();
-
-    // Clear canvas
-    ctx.clearRect(0, 0, width, canvasHeight);
-
-    // Optimized theme detection (using signal instead of DOM access)
+    const data = waveformData;
     const isDarkMode = isDarkSignal();
 
-    // Colors (Mechanical Etched Palette) - Cached values
+    ctx.clearRect(0, 0, width, canvasHeight);
+
     const bgColor = isDarkMode ? '#1e293b' : '#f1f5f9';
     const highlightColor = isDarkMode ? 'rgba(255, 255, 255, 0.05)' : 'rgba(255, 255, 255, 0.8)';
     const shadowColor = isDarkMode ? 'rgba(0, 0, 0, 0.4)' : 'rgba(0, 0, 0, 0.1)';
     const etchColor = isDarkMode ? '#334155' : '#cbd5e1';
     const signalActiveColor = '#3b82f6';
 
-    // Background
-    if (ctx) {
-      ctx.fillStyle = bgColor;
-      ctx.fillRect(0, 0, width, canvasHeight);
+    ctx.fillStyle = bgColor;
+    ctx.fillRect(0, 0, width, canvasHeight);
 
-      // Baseline (Etched indent)
-      ctx.beginPath();
-      ctx.strokeStyle = shadowColor;
-      ctx.lineWidth = 0.5;
-      ctx.moveTo(0, centerY);
-      ctx.lineTo(width, centerY);
-      ctx.stroke();
+    ctx.beginPath();
+    ctx.strokeStyle = shadowColor;
+    ctx.lineWidth = 0.5;
+    ctx.moveTo(0, centerY);
+    ctx.lineTo(width, centerY);
+    ctx.stroke();
 
-      // Draw time markers at the top
-      if (showTimeMarkers() && props.audioEngine) {
-        // Use the new textColor and tickColor based on the etched palette
-        const textColor = isDarkMode ? '#94a3b8' : '#94a3b8';
-        const tickColor = isDarkMode ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.05)';
-        drawTimeMarkers(width, canvasHeight, textColor, tickColor);
-      }
+    if (showTimeMarkers() && props.audioEngine) {
+      const textColor = '#94a3b8';
+      const tickColor = isDarkMode ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.05)';
+      drawTimeMarkers(width, canvasHeight, textColor, tickColor);
+    }
 
-      // Draw segment boundaries (before waveform so they appear behind)
-      if (props.audioEngine) {
-        drawSegments(width, canvasHeight, isDarkMode);
-      }
+    if (props.audioEngine) {
+      drawSegments(width, canvasHeight, isDarkMode);
+    }
 
-      // Draw waveform using legacy UI project logic (Etched Mercury Style)
-      if (data.length >= 2) {
-        // Data is already subsampled to ~400 points (min, max pairs)
-        const numPoints = data.length / 2;
-        const step = width / numPoints; // Use simple step as points ~ width/2
+    if (data.length >= 2) {
+      const numPoints = data.length / 2;
+      const step = width / numPoints;
+      ctx.lineCap = 'round';
 
-        // Helper to draw the full waveform path
-        // Optimized Waveform Path (Consolidated passes)
-        ctx.lineCap = 'round';
+      const drawPath = (offsetX: number, offsetY: number) => {
+        if (!ctx) return;
+        ctx.beginPath();
+        for (let i = 0; i < numPoints; i++) {
+          const x = i * step + offsetX;
+          let minVal = data[i * 2];
+          let maxVal = data[i * 2 + 1];
 
-        // Helper to draw the full waveform path
-        const drawPath = (offsetX: number, offsetY: number) => {
-          if (!ctx) return;
-          ctx.beginPath();
-          for (let i = 0; i < numPoints; i++) {
-            const x = i * step + offsetX;
-            // Ensure min/max have at least 1px difference for visibility even when silent
-            let minVal = data[i * 2];
-            let maxVal = data[i * 2 + 1];
+          let yMin = centerY - (minVal * centerY * 0.9) + offsetY;
+          let yMax = centerY - (maxVal * centerY * 0.9) + offsetY;
 
-            // Scaled values
-            let yMin = centerY - (minVal * centerY * 0.9) + offsetY;
-            let yMax = centerY - (maxVal * centerY * 0.9) + offsetY;
-
-            // Ensure tiny signals are visible (min 1px height)
-            if (Math.abs(yMax - yMin) < 1) {
-              yMin = centerY - 0.5 + offsetY;
-              yMax = centerY + 0.5 + offsetY;
-            }
-
-            ctx.moveTo(x, yMin);
-            ctx.lineTo(x, yMax);
+          if (Math.abs(yMax - yMin) < 1) {
+            yMin = centerY - 0.5 + offsetY;
+            yMax = centerY + 0.5 + offsetY;
           }
-          ctx.stroke();
-        };
 
-        // 1. Highlight Pass (Sharp top-left edge)
-        ctx.strokeStyle = highlightColor;
-        ctx.lineWidth = 1.0;
-        drawPath(-0.5, -0.5);
+          ctx.moveTo(x, yMin);
+          ctx.lineTo(x, yMax);
+        }
+        ctx.stroke();
+      };
 
-        // 2. Shadow Pass (Depressed groove)
-        ctx.strokeStyle = shadowColor;
-        ctx.lineWidth = 1.2;
-        drawPath(0.5, 0.5);
+      ctx.strokeStyle = highlightColor;
+      ctx.lineWidth = 1.0;
+      drawPath(-0.5, -0.5);
 
-        // 3. Main Etch Pass (Base material) - Slate color for contrast
-        ctx.strokeStyle = etchColor;
+      ctx.strokeStyle = shadowColor;
+      ctx.lineWidth = 1.2;
+      drawPath(0.5, 0.5);
+
+      ctx.strokeStyle = etchColor;
+      ctx.lineWidth = 1.0;
+      drawPath(0, 0);
+
+      if (currentMetrics.isSpeaking) {
+        ctx.globalAlpha = 0.5;
+        ctx.shadowBlur = 4;
+        ctx.shadowColor = signalActiveColor;
+        ctx.strokeStyle = signalActiveColor;
         ctx.lineWidth = 1.0;
         drawPath(0, 0);
-
-        // 4. Active signal glow
-        if (currentMetrics.isSpeaking) {
-          ctx.globalAlpha = 0.5;
-          ctx.shadowBlur = 4;
-          ctx.shadowColor = signalActiveColor;
-          ctx.strokeStyle = signalActiveColor;
-          ctx.lineWidth = 1.0;
-          drawPath(0, 0);
-          ctx.shadowBlur = 0;
-          ctx.globalAlpha = 1.0;
-        }
-      }
-
-      // Draw adaptive threshold (Etched dashes)
-      if (showThreshold() && currentMetrics.noiseFloor > 0) {
-        const snrRatio = Math.pow(10, snrThreshold() / 10);
-        const adaptiveThreshold = currentMetrics.noiseFloor * snrRatio;
-
-        const drawThresholdLine = (offsetY: number, color: string) => {
-          if (!ctx) return;
-          ctx.beginPath();
-          ctx.strokeStyle = color;
-          ctx.lineWidth = 1;
-          ctx.setLineDash([2, 4]);
-          const adaptiveYPos = centerY - adaptiveThreshold * centerY + offsetY;
-          ctx.moveTo(0, adaptiveYPos); ctx.lineTo(width, adaptiveYPos);
-          const adaptiveYNeg = centerY + adaptiveThreshold * centerY + offsetY;
-          ctx.moveTo(0, adaptiveYNeg); ctx.lineTo(width, adaptiveYNeg);
-          ctx.stroke();
-        };
-
-        drawThresholdLine(1, highlightColor);
-        drawThresholdLine(0, shadowColor);
-        ctx.setLineDash([]);
-
-        // Label (Etched text)
-        ctx.fillStyle = isDarkMode ? 'rgba(255, 255, 255, 0.15)' : 'rgba(0, 0, 0, 0.2)';
-        ctx.font = '900 9px "JetBrains Mono", monospace';
-        const labelY = centerY - adaptiveThreshold * centerY - 8;
-        ctx.fillText(`THRSH: ${snrThreshold().toFixed(1)}dB`, 10, labelY);
-      }
-
-      // Draw noise floor level (retained original style for clarity)
-      if (currentMetrics.noiseFloor > 0) {
-        const nfColor = isDarkMode ? 'rgba(74, 222, 128, 0.1)' : 'rgba(34, 197, 94, 0.1)';
-        const noiseFloorY = centerY - currentMetrics.noiseFloor * centerY;
-        const noiseFloorYNeg = centerY + currentMetrics.noiseFloor * centerY;
-
-        ctx.beginPath();
-        ctx.strokeStyle = nfColor;
-        ctx.lineWidth = 1;
-        ctx.moveTo(0, noiseFloorY);
-        ctx.lineTo(width, noiseFloorY);
-        ctx.moveTo(0, noiseFloorYNeg);
-        ctx.lineTo(width, noiseFloorYNeg);
-        ctx.stroke();
-      }
-
-      // Draw speaking indicator (Neumorphic dot)
-      if (currentMetrics.isSpeaking) {
-        const speakingColor = '#22c55e';
-        const indicatorX = width - 60;
-        const indicatorY = 25;
-        const radius = 6;
-
-        // Glow effect
-        ctx.shadowBlur = 10;
-        ctx.shadowColor = speakingColor;
-
-        ctx.beginPath();
-        ctx.arc(indicatorX, indicatorY, radius, 0, Math.PI * 2);
-        ctx.fillStyle = speakingColor;
-        ctx.fill();
-
         ctx.shadowBlur = 0;
-
-        // Pulse ring
-        const time = performance.now() / 1000;
-        const rippleRadius = radius + (time % 1) * 10;
-        const rippleOpacity = 1 - (time % 1);
-
-        ctx.beginPath();
-        ctx.arc(indicatorX, indicatorY, rippleRadius, 0, Math.PI * 2);
-        ctx.strokeStyle = `rgba(34, 197, 94, ${rippleOpacity})`;
-        ctx.lineWidth = 1.5;
-        ctx.stroke();
+        ctx.globalAlpha = 1.0;
       }
+    }
 
-      // SNR meter on the right side - Etched mechanical gauge
-      if (currentMetrics.currentSNR > 0) {
-        const meterPadding = 15;
-        const meterWidth = 6;
-        const meterX = width - 20;
-        const meterHeight = canvasHeight - (meterPadding * 2);
+    if (showThreshold() && currentMetrics.noiseFloor > 0) {
+      const snrRatio = Math.pow(10, snrThreshold() / 10);
+      const adaptiveThreshold = currentMetrics.noiseFloor * snrRatio;
 
-        // Meter Housing (Inset)
-        ctx.fillStyle = shadowColor;
+      const drawThresholdLine = (offsetY: number, color: string) => {
+        if (!ctx) return;
         ctx.beginPath();
-        ctx.roundRect(meterX, meterPadding, meterWidth, meterHeight, 3);
-        ctx.fill();
-
-        ctx.strokeStyle = highlightColor;
+        ctx.strokeStyle = color;
         ctx.lineWidth = 1;
+        ctx.setLineDash([2, 4]);
+        const adaptiveYPos = centerY - adaptiveThreshold * centerY + offsetY;
+        ctx.moveTo(0, adaptiveYPos);
+        ctx.lineTo(width, adaptiveYPos);
+        const adaptiveYNeg = centerY + adaptiveThreshold * centerY + offsetY;
+        ctx.moveTo(0, adaptiveYNeg);
+        ctx.lineTo(width, adaptiveYNeg);
         ctx.stroke();
+      };
 
-        // Gauge Level
-        const maxSNR = 60;
-        const cappedSNR = Math.min(maxSNR, currentMetrics.currentSNR);
-        const fillHeight = (cappedSNR / maxSNR) * meterHeight;
-        const fillY = (meterPadding + meterHeight) - fillHeight;
+      drawThresholdLine(1, highlightColor);
+      drawThresholdLine(0, shadowColor);
+      ctx.setLineDash([]);
 
-        // Glow for the active portion
-        ctx.shadowBlur = 8;
-        ctx.shadowColor = currentMetrics.currentSNR >= snrThreshold() ? 'rgba(34, 197, 94, 0.4)' : 'rgba(96, 165, 250, 0.4)';
+      ctx.fillStyle = isDarkMode ? 'rgba(255, 255, 255, 0.15)' : 'rgba(0, 0, 0, 0.2)';
+      ctx.font = '900 9px "JetBrains Mono", monospace';
+      const labelY = centerY - adaptiveThreshold * centerY - 8;
+      ctx.fillText(`THRSH: ${snrThreshold().toFixed(1)}dB`, 10, labelY);
+    }
 
-        ctx.fillStyle = currentMetrics.currentSNR >= snrThreshold() ? '#22c55e' : signalActiveColor;
-        ctx.beginPath();
-        ctx.roundRect(meterX, fillY, meterWidth, fillHeight, 3);
-        ctx.fill();
+    if (currentMetrics.noiseFloor > 0) {
+      const nfColor = isDarkMode ? 'rgba(74, 222, 128, 0.1)' : 'rgba(34, 197, 94, 0.1)';
+      const noiseFloorY = centerY - currentMetrics.noiseFloor * centerY;
+      const noiseFloorYNeg = centerY + currentMetrics.noiseFloor * centerY;
 
-        ctx.shadowBlur = 0;
+      ctx.beginPath();
+      ctx.strokeStyle = nfColor;
+      ctx.lineWidth = 1;
+      ctx.moveTo(0, noiseFloorY);
+      ctx.lineTo(width, noiseFloorY);
+      ctx.moveTo(0, noiseFloorYNeg);
+      ctx.lineTo(width, noiseFloorYNeg);
+      ctx.stroke();
+    }
 
-        // Threshold marker notched in
-        const thresholdMarkerY = (meterPadding + meterHeight) - (Math.min(maxSNR, snrThreshold()) / maxSNR * meterHeight);
-        ctx.beginPath();
-        ctx.strokeStyle = '#ef4444';
-        ctx.lineWidth = 2;
-        ctx.moveTo(meterX - 4, thresholdMarkerY);
-        ctx.lineTo(meterX + meterWidth + 4, thresholdMarkerY);
-        ctx.stroke();
+    if (currentMetrics.isSpeaking) {
+      const speakingColor = '#22c55e';
+      const indicatorX = width - 60;
+      const indicatorY = 25;
+      const radius = 6;
 
-        // Digital Readout
-        ctx.fillStyle = isDarkMode ? '#f8fafc' : '#1e293b';
-        ctx.font = '900 10px "JetBrains Mono", monospace';
-        ctx.textAlign = 'right';
-        ctx.fillText(`${currentMetrics.currentSNR.toFixed(0)}`, meterX - 8, thresholdMarkerY + 4);
-        ctx.textAlign = 'left';
-      }
+      ctx.shadowBlur = 10;
+      ctx.shadowColor = speakingColor;
+
+      ctx.beginPath();
+      ctx.arc(indicatorX, indicatorY, radius, 0, Math.PI * 2);
+      ctx.fillStyle = speakingColor;
+      ctx.fill();
+
+      ctx.shadowBlur = 0;
+
+      const time = performance.now() / 1000;
+      const rippleRadius = radius + (time % 1) * 10;
+      const rippleOpacity = 1 - (time % 1);
+
+      ctx.beginPath();
+      ctx.arc(indicatorX, indicatorY, rippleRadius, 0, Math.PI * 2);
+      ctx.strokeStyle = `rgba(34, 197, 94, ${rippleOpacity})`;
+      ctx.lineWidth = 1.5;
+      ctx.stroke();
+    }
+
+    if (currentMetrics.currentSNR > 0) {
+      const meterPadding = 15;
+      const meterWidth = 6;
+      const meterX = width - 20;
+      const meterHeight = canvasHeight - (meterPadding * 2);
+
+      ctx.fillStyle = shadowColor;
+      ctx.beginPath();
+      ctx.roundRect(meterX, meterPadding, meterWidth, meterHeight, 3);
+      ctx.fill();
+
+      ctx.strokeStyle = highlightColor;
+      ctx.lineWidth = 1;
+      ctx.stroke();
+
+      const maxSNR = 60;
+      const cappedSNR = Math.min(maxSNR, currentMetrics.currentSNR);
+      const fillHeight = (cappedSNR / maxSNR) * meterHeight;
+      const fillY = (meterPadding + meterHeight) - fillHeight;
+
+      ctx.shadowBlur = 8;
+      ctx.shadowColor =
+        currentMetrics.currentSNR >= snrThreshold() ? 'rgba(34, 197, 94, 0.4)' : 'rgba(96, 165, 250, 0.4)';
+
+      ctx.fillStyle = currentMetrics.currentSNR >= snrThreshold() ? '#22c55e' : signalActiveColor;
+      ctx.beginPath();
+      ctx.roundRect(meterX, fillY, meterWidth, fillHeight, 3);
+      ctx.fill();
+
+      ctx.shadowBlur = 0;
+
+      const thresholdMarkerY = (meterPadding + meterHeight) - (Math.min(maxSNR, snrThreshold()) / maxSNR * meterHeight);
+      ctx.beginPath();
+      ctx.strokeStyle = '#ef4444';
+      ctx.lineWidth = 2;
+      ctx.moveTo(meterX - 4, thresholdMarkerY);
+      ctx.lineTo(meterX + meterWidth + 4, thresholdMarkerY);
+      ctx.stroke();
+
+      ctx.fillStyle = isDarkMode ? '#f8fafc' : '#1e293b';
+      ctx.font = '900 10px "JetBrains Mono", monospace';
+      ctx.textAlign = 'right';
+      ctx.fillText(`${currentMetrics.currentSNR.toFixed(0)}`, meterX - 8, thresholdMarkerY + 4);
+      ctx.textAlign = 'left';
     }
   };
 
-  // Draw time markers
   const drawTimeMarkers = (width: number, canvasHeight: number, textColor: string, tickColor: string) => {
     if (!ctx || !props.audioEngine) return;
 
     const bufferDuration = props.audioEngine.getVisualizationDuration();
-    const currentTime = bufferEndTime(); // Use synchronized end time of buffer
+    const currentTime = currentBufferEndTime;
     const windowStart = currentTime - bufferDuration;
 
     ctx.fillStyle = textColor;
     ctx.font = '10px system-ui, sans-serif';
 
-    const markerInterval = 5; // Every 5 seconds
+    const markerInterval = 5;
     const firstMarkerTime = Math.ceil(windowStart / markerInterval) * markerInterval;
 
     for (let time = firstMarkerTime; time <= currentTime; time += markerInterval) {
       const x = ((time - windowStart) / bufferDuration) * width;
-
-      // Draw tick mark
       ctx.beginPath();
       ctx.strokeStyle = tickColor;
       ctx.moveTo(x, 0);
       ctx.lineTo(x, 15);
       ctx.stroke();
-
-      // Draw time label
       ctx.fillText(`${time}s`, x + 2, 12);
     }
   };
 
-  // Draw segment boundaries
   const drawSegments = (width: number, canvasHeight: number, isDarkMode: boolean) => {
     const context = ctx;
     if (!context || !props.audioEngine) return;
 
     const bufferDuration = props.audioEngine.getVisualizationDuration();
-    const currentTime = bufferEndTime(); // Use synchronized end time of buffer
+    const currentTime = currentBufferEndTime;
     const windowStart = currentTime - bufferDuration;
-    const segmentList = segments();
 
-    // Colors for segments
-    const pendingColor = isDarkMode ? 'rgba(250, 204, 21, 0.15)' : 'rgba(234, 179, 8, 0.15)';
-    const processedColor = isDarkMode ? 'rgba(34, 197, 94, 0.15)' : 'rgba(22, 163, 74, 0.15)';
     const pendingBorderColor = isDarkMode ? 'rgba(250, 204, 21, 0.5)' : 'rgba(234, 179, 8, 0.5)';
     const processedBorderColor = isDarkMode ? 'rgba(34, 197, 94, 0.5)' : 'rgba(22, 163, 74, 0.5)';
 
-    // Log segment count for debugging
-    // console.log('Drawing segments:', segmentList.length);
-
-    segmentList.forEach(segment => {
-      // Calculate relative position in visualization window
+    currentSegments.forEach(segment => {
       const relativeStart = segment.startTime - windowStart;
       const relativeEnd = segment.endTime - windowStart;
 
-      // Only draw if segment is within visible window
       if (relativeEnd > 0 && relativeStart < bufferDuration) {
-        // Pixel-snap boundaries to prevent anti-aliasing jitter/widening
-        const startX = Math.floor(Math.max(0, (relativeStart / bufferDuration)) * width);
-        const endX = Math.ceil(Math.min(1, (relativeEnd / bufferDuration)) * width);
+        const startX = Math.floor(Math.max(0, relativeStart / bufferDuration) * width);
+        const endX = Math.ceil(Math.min(1, relativeEnd / bufferDuration) * width);
 
-        // Fill segment area - increased opacity for visibility
-        context.fillStyle = segment.isProcessed ?
-          (isDarkMode ? 'rgba(34, 197, 94, 0.3)' : 'rgba(22, 163, 74, 0.3)') :
-          (isDarkMode ? 'rgba(250, 204, 21, 0.3)' : 'rgba(234, 179, 8, 0.3)');
-
+        context.fillStyle = segment.isProcessed
+          ? (isDarkMode ? 'rgba(34, 197, 94, 0.3)' : 'rgba(22, 163, 74, 0.3)')
+          : (isDarkMode ? 'rgba(250, 204, 21, 0.3)' : 'rgba(234, 179, 8, 0.3)');
         context.fillRect(startX, 0, endX - startX, canvasHeight);
 
-        // Draw segment boundaries (snap to pixel + 0.5 for sharp 1px lines)
         context.strokeStyle = segment.isProcessed ? processedBorderColor : pendingBorderColor;
         context.lineWidth = 1;
         context.beginPath();
@@ -395,88 +331,77 @@ export const BufferVisualizer: Component<BufferVisualizerProps> = (props) => {
     });
   };
 
-  // Animation loop
   const drawLoop = () => {
     if (!ctx || !canvasRef || canvasRef.width === 0) {
-      if (visible()) {
-        scheduleRaf();
-      } else {
-        scheduleTimeout();
+      cancelLoop();
+      return;
+    }
+
+    if (!isActive()) {
+      cancelLoop();
+      if (needsRedraw) {
+        needsRedraw = false;
+        draw();
       }
       return;
     }
 
-    if (visible()) {
-      const now = performance.now();
-      if (needsRedraw && now - lastDrawTime >= DRAW_INTERVAL_MS) {
-        lastDrawTime = now;
-        needsRedraw = false;
-        draw();
-      }
-      scheduleRaf();
-    } else {
-      // When not visible, check less frequently to save CPU
-      scheduleTimeout();
+    const now = performance.now();
+    if (needsRedraw && now - lastDrawTime >= DRAW_INTERVAL_MS) {
+      lastDrawTime = now;
+      needsRedraw = false;
+      draw();
     }
+    rafId = requestAnimationFrame(drawLoop);
   };
 
-  // Resize handler
   const handleResize = () => {
-    if (canvasRef && parentRef) {
-      const newWidth = parentRef.clientWidth;
-      if (newWidth > 0 && newWidth !== canvasWidth()) {
-        canvasRef.width = newWidth;
-        canvasRef.height = height();
-        setCanvasWidth(newWidth);
+    if (!canvasRef || !parentRef) return;
+    const newWidth = parentRef.clientWidth;
+    if (newWidth <= 0 || newWidth === canvasWidth) return;
 
-        // Refetch visualization data for new width
-        if (props.audioEngine && visible()) {
-          setWaveformData(props.audioEngine.getVisualizationData(newWidth));
-          needsRedraw = true;
-          // Note: can't update bufferEndTime here easily without calling another method on engine,
-          // but next update loop will catch it.
-        }
-      }
-    }
-  };
+    canvasRef.width = newWidth;
+    canvasRef.height = height();
+    canvasWidth = newWidth;
 
-  // Subscribe to audio engine updates
-  createEffect(() => {
-    const engine = props.audioEngine;
-    if (engine && visible()) {
-      // Initial data fetch
-      if (canvasWidth() > 0) {
-        setWaveformData(engine.getVisualizationData(canvasWidth()));
-        setBufferEndTime(engine.getCurrentTime());
-      }
-
-      // Subscribe to updates
-      const sub = engine.onVisualizationUpdate((data, newMetrics, endTime) => {
-        if (visible()) {
-          // Optimization: Reuse shared buffer from AudioEngine to avoid GC.
-          // The buffer content is mutable and updated in place by the engine.
-          setWaveformData(data);
-          setMetrics(newMetrics);
-          setBufferEndTime(endTime);
-
-          // Fetch segments for visualization
-          setSegments(engine.getSegmentsForVisualization());
-          needsRedraw = true;
-        } else {
-          // Still update metrics even when not visible
-          setMetrics(newMetrics);
-        }
-      });
-
-      onCleanup(() => sub());
-    }
-  });
-
-  // Mark for redraw when visibility toggles
-  createEffect(() => {
-    if (visible()) {
+    if (props.audioEngine && isActive()) {
+      waveformData = props.audioEngine.getVisualizationData(newWidth);
+      currentBufferEndTime = props.audioEngine.getCurrentTime();
+      currentSegments = props.audioEngine.getSegmentsForVisualization();
       needsRedraw = true;
     }
+    drawLoop();
+  };
+
+  createEffect(() => {
+    const engine = props.audioEngine;
+    if (!engine || !isActive()) return;
+
+    if (canvasWidth > 0) {
+      waveformData = engine.getVisualizationData(canvasWidth);
+      currentBufferEndTime = engine.getCurrentTime();
+      currentSegments = engine.getSegmentsForVisualization();
+      currentMetrics = engine.getMetrics();
+      needsRedraw = true;
+    }
+
+    const sub = engine.onVisualizationUpdate((data, newMetrics, endTime) => {
+      waveformData = data;
+      currentMetrics = newMetrics;
+      currentBufferEndTime = endTime;
+      currentSegments = engine.getSegmentsForVisualization();
+      needsRedraw = true;
+    });
+
+    onCleanup(() => sub());
+  });
+
+  createEffect(() => {
+    visible();
+    pageVisible();
+    lastDrawTime = 0;
+    needsRedraw = true;
+    drawLoop();
   });
 
   onMount(() => {
@@ -484,45 +409,30 @@ export const BufferVisualizer: Component<BufferVisualizerProps> = (props) => {
       ctx = canvasRef.getContext('2d');
     }
 
-    // Setup dark mode observer
     setIsDarkSignal(document.documentElement.classList.contains('dark'));
     const themeObserver = new MutationObserver(() => {
       setIsDarkSignal(document.documentElement.classList.contains('dark'));
+      needsRedraw = true;
+      drawLoop();
     });
     themeObserver.observe(document.documentElement, {
       attributes: true,
       attributeFilter: ['class'],
     });
-
     onCleanup(() => themeObserver.disconnect());
 
-    // Setup resize observer
     handleResize();
     resizeObserver = new ResizeObserver(handleResize);
     if (parentRef) {
       resizeObserver.observe(parentRef);
     }
 
-    // Start animation loop
-    if (visible()) {
-      scheduleRaf();
-    } else {
-      scheduleTimeout();
-    }
+    drawLoop();
   });
 
   onCleanup(() => {
-    if (rafId !== undefined) {
-      cancelAnimationFrame(rafId);
-      rafId = undefined;
-    }
-    if (timeoutId !== undefined) {
-      clearTimeout(timeoutId);
-      timeoutId = undefined;
-    }
-    if (resizeObserver) {
-      resizeObserver.disconnect();
-    }
+    cancelLoop();
+    resizeObserver?.disconnect();
   });
 
   return (

--- a/src/components/ContextPanel.tsx
+++ b/src/components/ContextPanel.tsx
@@ -41,6 +41,7 @@ export const ContextPanel: Component<ContextPanelProps> = (props) => {
         <div
           class="w-full max-w-md mx-4 bg-[var(--color-earthy-bg)] rounded-2xl border border-[var(--color-earthy-sage)] shadow-xl overflow-hidden"
           onClick={(e) => e.stopPropagation()}
+          role="presentation"
         >
           <div class="px-6 py-4 border-b border-[var(--color-earthy-sage)]/30 flex items-center justify-between">
             <h2 class="text-lg font-semibold tracking-tight text-[var(--color-earthy-dark-brown)]">Context</h2>

--- a/src/components/DebugPanel.tsx
+++ b/src/components/DebugPanel.tsx
@@ -57,6 +57,7 @@ export const DebugPanel: Component<DebugPanelProps> = (props) => {
   let startY = 0;
   let startHeight = 0;
   let activePointerId: number | null = null;
+  const resizeStep = 24;
   const handlePointerDown = (e: PointerEvent) => {
     e.preventDefault();
     setIsResizing(true);
@@ -87,6 +88,33 @@ export const DebugPanel: Component<DebugPanelProps> = (props) => {
     window.removeEventListener('pointerup', handlePointerUp);
     window.removeEventListener('pointercancel', handlePointerUp);
   };
+  const handleResizeKeyDown = (e: KeyboardEvent) => {
+    let nextHeight: number | null = null;
+    switch (e.key) {
+      case 'ArrowUp':
+        nextHeight = panelHeight() + resizeStep;
+        break;
+      case 'ArrowDown':
+        nextHeight = panelHeight() - resizeStep;
+        break;
+      case 'PageUp':
+        nextHeight = panelHeight() + resizeStep * 2;
+        break;
+      case 'PageDown':
+        nextHeight = panelHeight() - resizeStep * 2;
+        break;
+      case 'Home':
+        nextHeight = MIN_DEBUG_PANEL_HEIGHT;
+        break;
+      case 'End':
+        nextHeight = getMaxHeight();
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    setPanelHeight(nextHeight);
+  };
 
   onCleanup(() => {
     activePointerId = null;
@@ -101,7 +129,7 @@ export const DebugPanel: Component<DebugPanelProps> = (props) => {
     const rtfx = appStore.rtfxAverage();
     if (rtfx === 0) return 'text-[var(--color-earthy-soft-brown)]';
     if (rtfx >= 2) return 'text-[var(--color-earthy-muted-green)] font-bold';
-    if (rtfx >= 1) return 'text-[var(--color-earthy-coral)] font-bold';
+    if (rtfx >= 1) return 'text-[var(--color-earthy-dark-brown)] font-bold';
     return 'text-[var(--color-earthy-coral)] font-bold';
   });
   return (
@@ -113,9 +141,14 @@ export const DebugPanel: Component<DebugPanelProps> = (props) => {
       <div
         class="h-3 shrink-0 cursor-row-resize group touch-none select-none flex items-center justify-center relative"
         onPointerDown={handlePointerDown}
+        onKeyDown={handleResizeKeyDown}
         role="separator"
         aria-orientation="horizontal"
         aria-label="Resize debug panel"
+        aria-valuemin={MIN_DEBUG_PANEL_HEIGHT}
+        aria-valuemax={getMaxHeight()}
+        aria-valuenow={panelHeight()}
+        tabIndex={0}
       >
         <div class={`relative z-10 h-2.5 w-10 rounded-full border shadow-sm transition-colors ${isResizing() ? 'bg-[var(--color-earthy-sage)] border-[var(--color-earthy-muted-green)]/80' : 'bg-[var(--color-earthy-bg)] border-[var(--color-earthy-sage)]/60 group-hover:border-[var(--color-earthy-soft-brown)]/80'}`} />
       </div>

--- a/src/components/LayeredBufferVisualizer.tsx
+++ b/src/components/LayeredBufferVisualizer.tsx
@@ -1,8 +1,9 @@
-import { Component, onMount, onCleanup, createSignal } from 'solid-js';
+import { Component, createEffect, onCleanup, onMount } from 'solid-js';
 import type { AudioEngine } from '../lib/audio/types';
 import type { MelWorkerClient } from '../lib/audio/MelWorkerClient';
 import { MEL_DISPLAY_DB_RANGE, MEL_DISPLAY_MIN_DB } from '../lib/audio/mel-display';
 import { appStore } from '../stores/appStore';
+import { usePageVisible } from '../utils/usePageVisible';
 
 interface LayeredBufferVisualizerProps {
     /** Audio engine used for waveform and timing data. */
@@ -15,24 +16,18 @@ interface LayeredBufferVisualizerProps {
     windowDuration?: number; // default 8.0s
 }
 
-const MEL_BINS = 128; // Standard for this app
+const MEL_BINS = 128;
 
-// dB scaling is in mel-display.ts (shared with bar visualizer)
-
-// Pre-computed 256-entry RGB lookup table for mel heatmap (black to red).
-// Built once at module load; indexed by Math.round(intensity * 255).
-// Colormap: black -> blue -> purple -> green -> yellow -> orange -> red.
 const COLORMAP_LUT = (() => {
     const stops: [number, number, number, number][] = [
-        [0, 0, 0, 0],       // black
-        [0.12, 0, 0, 180],  // blue
-        [0.30, 120, 0, 160], // purple
-        [0.48, 0, 180, 80],  // green
-        [0.65, 220, 220, 0], // yellow
-        [0.82, 255, 140, 0], // orange
-        [1, 255, 0, 0],      // red
+        [0, 0, 0, 0],
+        [0.12, 0, 0, 180],
+        [0.30, 120, 0, 160],
+        [0.48, 0, 180, 80],
+        [0.65, 220, 220, 0],
+        [0.82, 255, 140, 0],
+        [1, 255, 0, 0],
     ];
-    // 256 entries * 3 channels (R, G, B) packed into a Uint8Array
     const lut = new Uint8Array(256 * 3);
     for (let i = 0; i < 256; i++) {
         const intensity = i / 255;
@@ -50,7 +45,9 @@ const COLORMAP_LUT = (() => {
         }
         if (intensity >= stops[stops.length - 1][0]) {
             const last = stops[stops.length - 1];
-            r = last[1]; g = last[2]; b = last[3];
+            r = last[1];
+            g = last[2];
+            b = last[3];
         }
         const base = i * 3;
         lut[base] = r;
@@ -64,28 +61,21 @@ const COLORMAP_LUT = (() => {
 export const LayeredBufferVisualizer: Component<LayeredBufferVisualizerProps> = (props) => {
     let canvasRef: HTMLCanvasElement | undefined;
     let ctx: CanvasRenderingContext2D | null = null;
-    let animationFrameId: number;
+    let animationFrameId: number | undefined;
     let disposed = false;
 
     const getWindowDuration = () => props.windowDuration || 8.0;
+    const pageVisible = usePageVisible();
 
-    // Offscreen canvas for spectrogram caching (scrolling)
     let specCanvas: HTMLCanvasElement | undefined;
     let specCtx: CanvasRenderingContext2D | null = null;
 
-    // State for last fetch to throttle spectrogram updates
     let lastSpecFetchTime = 0;
     const DRAW_INTERVAL_FOREGROUND_MS = 33;
-    const DRAW_INTERVAL_IDLE_MS = 100;
-    const DRAW_INTERVAL_HIDDEN_MS = 220;
     const SPEC_FETCH_INTERVAL_FOREGROUND_MS = 100;
-    const SPEC_FETCH_INTERVAL_IDLE_MS = 250;
-    const SPEC_FETCH_INTERVAL_HIDDEN_MS = 700;
     let lastDrawTime = 0;
+    let needsRedraw = true;
 
-    // --- Cached layout dimensions (updated via ResizeObserver, NOT per-frame) ---
-    // Avoids getBoundingClientRect() every animation frame which forces synchronous
-    // layout reflow and was the #1 perf bottleneck (1.5s layout-shift clusters).
     let cachedPhysicalWidth = 0;
     let cachedPhysicalHeight = 0;
     let cachedDpr = window.devicePixelRatio || 1;
@@ -93,13 +83,11 @@ export const LayeredBufferVisualizer: Component<LayeredBufferVisualizerProps> = 
     let dprMediaQuery: MediaQueryList | null = null;
     let dprChangeHandler: ((this: MediaQueryList, ev: MediaQueryListEvent) => any) | null = null;
 
-    /** Recompute physical canvas dimensions from cached logical size + DPR. */
     const updateCanvasDimensions = (logicalW: number, logicalH: number) => {
         cachedDpr = window.devicePixelRatio || 1;
         cachedPhysicalWidth = Math.floor(logicalW * cachedDpr);
         cachedPhysicalHeight = Math.floor(logicalH * cachedDpr);
 
-        // Resize canvases immediately so next frame uses correct size
         if (canvasRef && (canvasRef.width !== cachedPhysicalWidth || canvasRef.height !== cachedPhysicalHeight)) {
             canvasRef.width = cachedPhysicalWidth;
             canvasRef.height = cachedPhysicalHeight;
@@ -110,9 +98,6 @@ export const LayeredBufferVisualizer: Component<LayeredBufferVisualizerProps> = 
         }
     };
 
-    // --- Pre-allocated ImageData for spectrogram rendering ---
-    // Avoids creating a new ImageData object every spectrogram draw (~10fps),
-    // which caused GC pressure from large short-lived allocations.
     let cachedSpecImgData: ImageData | null = null;
     let cachedSpecImgWidth = 0;
     let cachedSpecImgHeight = 0;
@@ -123,12 +108,8 @@ export const LayeredBufferVisualizer: Component<LayeredBufferVisualizerProps> = 
     let cacheTimeSteps = 0;
     let cacheMelBins = 0;
 
-    // --- Pre-allocated waveform read buffer ---
-    // Avoids allocating a new Float32Array(~128000) every animation frame.
-    // Grows only when the required size exceeds current capacity.
     let waveformReadBuf: Float32Array | null = null;
 
-    // Store spectrogram data with its time alignment
     let cachedSpecData: {
         features: Float32Array;
         melBins: number;
@@ -137,212 +118,27 @@ export const LayeredBufferVisualizer: Component<LayeredBufferVisualizerProps> = 
         endTime: number;
     } | null = null;
 
-    onMount(() => {
-        disposed = false;
-        if (canvasRef) {
-            ctx = canvasRef.getContext('2d', { alpha: false });
-
-            // Use ResizeObserver to cache dimensions instead of per-frame getBoundingClientRect
-            resizeObserver = new ResizeObserver((entries) => {
-                for (const entry of entries) {
-                    // contentRect gives CSS-pixel (logical) dimensions without forcing layout
-                    const cr = entry.contentRect;
-                    updateCanvasDimensions(cr.width, cr.height);
-                }
-            });
-            resizeObserver.observe(canvasRef);
-
-            // Watch for DPR changes (browser zoom, display change)
-            const setupDprWatch = () => {
-                if (dprMediaQuery && dprChangeHandler) {
-                    dprMediaQuery.removeEventListener('change', dprChangeHandler);
-                }
-                dprMediaQuery = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
-                const onDprChange = () => {
-                    if (disposed) return;
-                    if (canvasRef) {
-                        const rect = canvasRef.getBoundingClientRect(); // one-time on zoom change only
-                        updateCanvasDimensions(rect.width, rect.height);
-                    }
-                    // Re-register for the next change at the new DPR
-                    setupDprWatch();
-                };
-                dprChangeHandler = onDprChange;
-                dprMediaQuery.addEventListener('change', onDprChange, { once: true });
-            };
-            setupDprWatch();
-
-            // Initial dimensions (one-time)
-            const rect = canvasRef.getBoundingClientRect();
-            updateCanvasDimensions(rect.width, rect.height);
+    const cancelLoop = () => {
+        if (animationFrameId !== undefined) {
+            cancelAnimationFrame(animationFrameId);
+            animationFrameId = undefined;
         }
-
-        // Create offscreen canvas
-        specCanvas = document.createElement('canvas');
-        specCtx = specCanvas.getContext('2d', { alpha: false });
-
-        loop();
-    });
-
-    onCleanup(() => {
-        disposed = true;
-        cancelAnimationFrame(animationFrameId);
-        if (resizeObserver) {
-            resizeObserver.disconnect();
-            resizeObserver = null;
-        }
-        if (dprMediaQuery && dprChangeHandler) {
-            dprMediaQuery.removeEventListener('change', dprChangeHandler);
-        }
-        dprMediaQuery = null;
-        dprChangeHandler = null;
-    });
-
-    const loop = (now: number = performance.now()) => {
-        if (disposed) return;
-        if (!ctx || !canvasRef || !props.audioEngine) {
-            animationFrameId = requestAnimationFrame(loop);
-            return;
-        }
-
-        const hidden = typeof document !== 'undefined' && document.visibilityState !== 'visible';
-        const recording = appStore.recordingState() === 'recording';
-        const drawInterval = hidden
-            ? DRAW_INTERVAL_HIDDEN_MS
-            : recording
-                ? DRAW_INTERVAL_FOREGROUND_MS
-                : DRAW_INTERVAL_IDLE_MS;
-        if (now - lastDrawTime < drawInterval) {
-            animationFrameId = requestAnimationFrame(loop);
-            return;
-        }
-        lastDrawTime = now;
-
-        // Use cached dimensions (updated by ResizeObserver / DPR watcher)
-        const dpr = cachedDpr;
-        const width = cachedPhysicalWidth;
-        const height = cachedPhysicalHeight;
-
-        if (width === 0 || height === 0) {
-            animationFrameId = requestAnimationFrame(loop);
-            return;
-        }
-
-        // Colors
-        const bgColor = '#0f172a';
-        ctx.fillStyle = bgColor;
-        ctx.fillRect(0, 0, width, height);
-
-        const ringBuffer = props.audioEngine.getRingBuffer();
-        const currentTime = ringBuffer.getCurrentTime();
-        const duration = getWindowDuration();
-        const startTime = currentTime - duration;
-        const sampleRate = ringBuffer.sampleRate;
-
-        // Layout: 
-        // Top 55%: Spectrogram
-        // Middle 35%: Waveform
-        // Bottom 10%: VAD signal
-        const specHeight = Math.floor(height * 0.55);
-        const waveHeight = Math.floor(height * 0.35);
-        const vadHeight = height - specHeight - waveHeight;
-        const waveY = specHeight;
-        const vadY = specHeight + waveHeight;
-
-        // 1. Spectrogram (async fetch with stored alignment)
-        if (props.melClient && specCtx && specCanvas) {
-            const specFetchInterval = hidden
-                ? SPEC_FETCH_INTERVAL_HIDDEN_MS
-                : recording
-                    ? SPEC_FETCH_INTERVAL_FOREGROUND_MS
-                    : SPEC_FETCH_INTERVAL_IDLE_MS;
-            if (now - lastSpecFetchTime > specFetchInterval) {
-                lastSpecFetchTime = now;
-
-                const fetchStartSample = Math.round(startTime * sampleRate);
-                const fetchEndSample = Math.round(currentTime * sampleRate);
-
-                // Request RAW (unnormalized) features for fixed dB scaling.
-                // ASR transcription still uses normalized features (default).
-                props.melClient.getFeatures(fetchStartSample, fetchEndSample, false).then(features => {
-                    if (disposed) return;
-                    if (features && specCtx && specCanvas) {
-                        // Store with time alignment info
-                        cachedSpecData = {
-                            features: features.features,
-                            melBins: features.melBins,
-                            timeSteps: features.T,
-                            startTime: startTime,
-                            endTime: currentTime
-                        };
-                        drawSpectrogramToCanvas(specCtx, features.features, features.melBins, features.T, width, specHeight);
-                    }
-                }).catch(() => { });
-            }
-
-            // Draw cached spectrogram aligned to current view
-            if (cachedSpecData && cachedSpecData.timeSteps > 0) {
-                // Calculate offset to align cached data with current time window
-                const cachedDuration = cachedSpecData.endTime - cachedSpecData.startTime;
-                const timeOffset = startTime - cachedSpecData.startTime;
-                const offsetX = Math.floor((timeOffset / cachedDuration) * width);
-
-                // Draw the portion of cached spectrogram that's still visible
-                ctx.drawImage(specCanvas, offsetX, 0, width - offsetX, specHeight, 0, 0, width - offsetX, specHeight);
-            }
-        }
-
-        // 2. Waveform (sync with current time window, zero-allocation read)
-        try {
-            const startSample = Math.floor(startTime * sampleRate);
-            const endSample = Math.floor(currentTime * sampleRate);
-            const neededLen = endSample - startSample;
-
-            const baseFrame = ringBuffer.getBaseFrameOffset();
-            if (startSample >= baseFrame && neededLen > 0) {
-                // Use readInto if available (zero-alloc), fall back to read()
-                if (ringBuffer.readInto) {
-                    // Grow the pre-allocated buffer only when capacity is insufficient
-                    if (!waveformReadBuf || waveformReadBuf.length < neededLen) {
-                        waveformReadBuf = new Float32Array(neededLen);
-                    }
-                    const written = ringBuffer.readInto(startSample, endSample, waveformReadBuf);
-                    // Pass a subarray view (no copy) of the exact length
-                    drawWaveform(ctx, waveformReadBuf.subarray(0, written), width, waveHeight, waveY);
-                } else {
-                    const audioData = ringBuffer.read(startSample, endSample);
-                    drawWaveform(ctx, audioData, width, waveHeight, waveY);
-                }
-            }
-        } catch (e) {
-            // Data likely overwritten or not available
-        }
-
-        // 3. VAD Signal Layer
-        drawVadLayer(ctx, width, vadHeight, vadY, startTime, duration, dpr);
-
-        // 4. Overlay (time labels, trigger line)
-        drawOverlay(ctx, width, height, startTime, duration, dpr);
-
-        animationFrameId = requestAnimationFrame(loop);
     };
 
+    const isActive = () => pageVisible() && appStore.recordingState() === 'recording';
+
     const drawSpectrogramToCanvas = (
-        ctx: CanvasRenderingContext2D,
+        targetCtx: CanvasRenderingContext2D,
         features: Float32Array,
         melBins: number,
         timeSteps: number,
         width: number,
         height: number
     ) => {
-        // features layout: [melBins, T] (mel-major, flattened from [mel, time])
-        // So features[m * timeSteps + t].
-
         if (timeSteps === 0 || width === 0 || height === 0) return;
 
-        // Reuse cached ImageData if dimensions match; allocate only on size change
         if (!cachedSpecImgData || cachedSpecImgWidth !== width || cachedSpecImgHeight !== height) {
-            cachedSpecImgData = ctx.createImageData(width, height);
+            cachedSpecImgData = targetCtx.createImageData(width, height);
             cachedSpecImgWidth = width;
             cachedSpecImgHeight = height;
         }
@@ -393,23 +189,21 @@ export const LayeredBufferVisualizer: Component<LayeredBufferVisualizerProps> = 
                 data[idx++] = 255;
             }
         }
-        ctx.putImageData(imgData, 0, 0);
+        targetCtx.putImageData(imgData, 0, 0);
     };
 
-    // Use gain 1 so waveform shows true amplitude (float32 in [-1,1] fills half-height).
-    // No display amplification; ASR pipeline is unchanged.
     const WAVEFORM_GAIN = 1;
 
-    const drawWaveform = (ctx: CanvasRenderingContext2D, data: Float32Array, width: number, height: number, offsetY: number) => {
+    const drawWaveform = (targetCtx: CanvasRenderingContext2D, data: Float32Array, width: number, height: number, offsetY: number) => {
         if (data.length === 0) return;
 
         const step = Math.ceil(data.length / width);
         const amp = (height / 2) * WAVEFORM_GAIN;
         const centerY = offsetY + height / 2;
 
-        ctx.strokeStyle = '#4ade80'; // Green
-        ctx.lineWidth = 1;
-        ctx.beginPath();
+        targetCtx.strokeStyle = '#4ade80';
+        targetCtx.lineWidth = 1;
+        targetCtx.beginPath();
 
         for (let x = 0; x < width; x++) {
             const startIdx = x * step;
@@ -429,66 +223,230 @@ export const LayeredBufferVisualizer: Component<LayeredBufferVisualizerProps> = 
             if (hasData) {
                 const yMin = centerY - min * amp;
                 const yMax = centerY - max * amp;
-                ctx.moveTo(x, Math.max(offsetY, Math.min(offsetY + height, yMin)));
-                ctx.lineTo(x, Math.max(offsetY, Math.min(offsetY + height, yMax)));
+                targetCtx.moveTo(x, Math.max(offsetY, Math.min(offsetY + height, yMin)));
+                targetCtx.lineTo(x, Math.max(offsetY, Math.min(offsetY + height, yMax)));
             }
         }
-        ctx.stroke();
+        targetCtx.stroke();
     };
 
-    const drawVadLayer = (ctx: CanvasRenderingContext2D, width: number, height: number, offsetY: number, startTime: number, duration: number, dpr: number) => {
-        // Draw VAD state as a colored bar
-        // For now, just show current VAD state as a solid bar (could be enhanced with historical data)
+    const drawVadLayer = (targetCtx: CanvasRenderingContext2D, width: number, height: number, offsetY: number, dpr: number) => {
         const vadState = appStore.vadState();
         const isSpeech = vadState.isSpeech;
 
-        // Background
-        ctx.fillStyle = isSpeech ? 'rgba(249, 115, 22, 0.4)' : 'rgba(100, 116, 139, 0.2)'; // Orange when speech, slate when silence
-        ctx.fillRect(0, offsetY, width, height);
+        targetCtx.fillStyle = isSpeech ? 'rgba(249, 115, 22, 0.4)' : 'rgba(100, 116, 139, 0.2)';
+        targetCtx.fillRect(0, offsetY, width, height);
 
-        // If energy-based detection is active, show energy level as a bar
         const energyLevel = appStore.audioLevel();
         const energyThreshold = appStore.energyThreshold();
 
         if (energyLevel > 0) {
-            const barWidth = Math.min(width, width * (energyLevel / 0.3)); // Scale to max 30% energy
-            ctx.fillStyle = energyLevel > energyThreshold ? 'rgba(249, 115, 22, 0.8)' : 'rgba(74, 222, 128, 0.6)';
-            ctx.fillRect(width - barWidth, offsetY, barWidth, height);
+            const barWidth = Math.min(width, width * (energyLevel / 0.3));
+            targetCtx.fillStyle = energyLevel > energyThreshold ? 'rgba(249, 115, 22, 0.8)' : 'rgba(74, 222, 128, 0.6)';
+            targetCtx.fillRect(width - barWidth, offsetY, barWidth, height);
         }
 
-        // Draw a thin separator line at top
-        ctx.strokeStyle = 'rgba(148, 163, 184, 0.3)';
-        ctx.lineWidth = 1 * dpr;
-        ctx.beginPath();
-        ctx.moveTo(0, offsetY);
-        ctx.lineTo(width, offsetY);
-        ctx.stroke();
+        targetCtx.strokeStyle = 'rgba(148, 163, 184, 0.3)';
+        targetCtx.lineWidth = 1 * dpr;
+        targetCtx.beginPath();
+        targetCtx.moveTo(0, offsetY);
+        targetCtx.lineTo(width, offsetY);
+        targetCtx.stroke();
 
-        // Label
-        ctx.fillStyle = isSpeech ? '#fb923c' : '#64748b';
-        ctx.font = `${8 * dpr}px monospace`;
-        ctx.fillText(isSpeech ? 'SPEECH' : 'SILENCE', 4 * dpr, offsetY + height - 2 * dpr);
+        targetCtx.fillStyle = isSpeech ? '#fb923c' : '#64748b';
+        targetCtx.font = `${8 * dpr}px monospace`;
+        targetCtx.fillText(isSpeech ? 'SPEECH' : 'SILENCE', 4 * dpr, offsetY + height - 2 * dpr);
     };
 
-    const drawOverlay = (ctx: CanvasRenderingContext2D, width: number, height: number, startTime: number, duration: number, dpr: number) => {
-        // Draw Trigger line (1.5s from right) if in V3 mode
+    const drawOverlay = (targetCtx: CanvasRenderingContext2D, width: number, height: number, duration: number, dpr: number) => {
         const triggerX = width - (1.5 / duration) * width;
-        ctx.strokeStyle = 'rgba(255, 255, 0, 0.5)';
-        ctx.lineWidth = 1 * dpr;
-        ctx.beginPath();
-        ctx.moveTo(triggerX, 0);
-        ctx.lineTo(triggerX, height);
-        ctx.stroke();
+        targetCtx.strokeStyle = 'rgba(255, 255, 0, 0.5)';
+        targetCtx.lineWidth = 1 * dpr;
+        targetCtx.beginPath();
+        targetCtx.moveTo(triggerX, 0);
+        targetCtx.lineTo(triggerX, height);
+        targetCtx.stroke();
 
-        // Time labels
-        ctx.fillStyle = '#94a3b8';
-        ctx.font = `${10 * dpr}px monospace`;
+        targetCtx.fillStyle = '#94a3b8';
+        targetCtx.font = `${10 * dpr}px monospace`;
         for (let i = 0; i <= 8; i += 2) {
-            const t = i;
-            const x = width - (t / duration) * width;
-            ctx.fillText(`-${t}s`, x + 3 * dpr, height - 6 * dpr);
+            const x = width - (i / duration) * width;
+            targetCtx.fillText(`-${i}s`, x + 3 * dpr, height - 6 * dpr);
         }
     };
+
+    const renderFrame = (now: number, allowFetch: boolean) => {
+        if (!ctx || !canvasRef || !props.audioEngine) return;
+
+        const dpr = cachedDpr;
+        const width = cachedPhysicalWidth;
+        const height = cachedPhysicalHeight;
+        if (width === 0 || height === 0) return;
+
+        ctx.fillStyle = '#0f172a';
+        ctx.fillRect(0, 0, width, height);
+
+        const ringBuffer = props.audioEngine.getRingBuffer();
+        const currentTime = ringBuffer.getCurrentTime();
+        const duration = getWindowDuration();
+        const startTime = currentTime - duration;
+        const sampleRate = ringBuffer.sampleRate;
+
+        const specHeight = Math.floor(height * 0.55);
+        const waveHeight = Math.floor(height * 0.35);
+        const vadHeight = height - specHeight - waveHeight;
+        const waveY = specHeight;
+        const vadY = specHeight + waveHeight;
+
+        if (props.melClient && specCtx && specCanvas) {
+            if (allowFetch && now - lastSpecFetchTime > SPEC_FETCH_INTERVAL_FOREGROUND_MS) {
+                lastSpecFetchTime = now;
+                const fetchStartSample = Math.round(startTime * sampleRate);
+                const fetchEndSample = Math.round(currentTime * sampleRate);
+
+                props.melClient.getFeatures(fetchStartSample, fetchEndSample, false).then(features => {
+                    if (disposed || !features || !specCtx || !specCanvas) return;
+                    cachedSpecData = {
+                        features: features.features,
+                        melBins: features.melBins,
+                        timeSteps: features.T,
+                        startTime,
+                        endTime: currentTime,
+                    };
+                    drawSpectrogramToCanvas(specCtx, features.features, features.melBins, features.T, width, specHeight);
+                    needsRedraw = true;
+                    if (!animationFrameId && !disposed) {
+                        renderFrame(performance.now(), false);
+                    }
+                }).catch(() => { });
+            }
+
+            if (cachedSpecData && cachedSpecData.timeSteps > 0) {
+                const cachedDuration = cachedSpecData.endTime - cachedSpecData.startTime;
+                if (cachedDuration > 0) {
+                    const timeOffset = startTime - cachedSpecData.startTime;
+                    const offsetX = Math.floor((timeOffset / cachedDuration) * width);
+                    ctx.drawImage(specCanvas, offsetX, 0, width - offsetX, specHeight, 0, 0, width - offsetX, specHeight);
+                }
+            }
+        }
+
+        try {
+            const startSample = Math.floor(startTime * sampleRate);
+            const endSample = Math.floor(currentTime * sampleRate);
+            const neededLen = endSample - startSample;
+            const baseFrame = ringBuffer.getBaseFrameOffset();
+
+            if (startSample >= baseFrame && neededLen > 0) {
+                if (ringBuffer.readInto) {
+                    if (!waveformReadBuf || waveformReadBuf.length < neededLen) {
+                        waveformReadBuf = new Float32Array(neededLen);
+                    }
+                    const written = ringBuffer.readInto(startSample, endSample, waveformReadBuf);
+                    drawWaveform(ctx, waveformReadBuf.subarray(0, written), width, waveHeight, waveY);
+                } else {
+                    const audioData = ringBuffer.read(startSample, endSample);
+                    drawWaveform(ctx, audioData, width, waveHeight, waveY);
+                }
+            }
+        } catch {
+            // Data may have been overwritten; skip this frame.
+        }
+
+        drawVadLayer(ctx, width, vadHeight, vadY, dpr);
+        drawOverlay(ctx, width, height, duration, dpr);
+    };
+
+    const loop = (now: number = performance.now()) => {
+        if (disposed) return;
+        if (!ctx || !canvasRef || !props.audioEngine) {
+            cancelLoop();
+            return;
+        }
+
+        if (!isActive()) {
+            cancelLoop();
+            if (needsRedraw) {
+                needsRedraw = false;
+                renderFrame(now, false);
+            }
+            return;
+        }
+
+        if (now - lastDrawTime < DRAW_INTERVAL_FOREGROUND_MS) {
+            animationFrameId = requestAnimationFrame(loop);
+            return;
+        }
+
+        lastDrawTime = now;
+        needsRedraw = false;
+        renderFrame(now, true);
+        animationFrameId = requestAnimationFrame(loop);
+    };
+
+    onMount(() => {
+        disposed = false;
+        if (canvasRef) {
+            ctx = canvasRef.getContext('2d', { alpha: false });
+
+            resizeObserver = new ResizeObserver((entries) => {
+                for (const entry of entries) {
+                    const cr = entry.contentRect;
+                    updateCanvasDimensions(cr.width, cr.height);
+                    needsRedraw = true;
+                    loop();
+                }
+            });
+            resizeObserver.observe(canvasRef);
+
+            const setupDprWatch = () => {
+                if (dprMediaQuery && dprChangeHandler) {
+                    dprMediaQuery.removeEventListener('change', dprChangeHandler);
+                }
+                dprMediaQuery = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
+                const onDprChange = () => {
+                    if (disposed) return;
+                    if (canvasRef) {
+                        const rect = canvasRef.getBoundingClientRect();
+                        updateCanvasDimensions(rect.width, rect.height);
+                    }
+                    needsRedraw = true;
+                    loop();
+                    setupDprWatch();
+                };
+                dprChangeHandler = onDprChange;
+                dprMediaQuery.addEventListener('change', onDprChange, { once: true });
+            };
+            setupDprWatch();
+
+            const rect = canvasRef.getBoundingClientRect();
+            updateCanvasDimensions(rect.width, rect.height);
+        }
+
+        specCanvas = document.createElement('canvas');
+        specCtx = specCanvas.getContext('2d', { alpha: false });
+
+        loop();
+    });
+
+    createEffect(() => {
+        pageVisible();
+        appStore.recordingState();
+        lastDrawTime = 0;
+        needsRedraw = true;
+        loop();
+    });
+
+    onCleanup(() => {
+        disposed = true;
+        cancelLoop();
+        resizeObserver?.disconnect();
+        if (dprMediaQuery && dprChangeHandler) {
+            dprMediaQuery.removeEventListener('change', dprChangeHandler);
+        }
+        dprMediaQuery = null;
+        dprChangeHandler = null;
+    });
 
     return (
         <div

--- a/src/components/Waveform.tsx
+++ b/src/components/Waveform.tsx
@@ -1,5 +1,6 @@
-import { Component, onCleanup, onMount } from 'solid-js';
+import { Component, createEffect, onCleanup, onMount } from 'solid-js';
 import type { WaveformProps } from '../types';
+import { usePageVisible } from '../utils/usePageVisible';
 
 /**
  * Oscilloscope-style waveform using AnalyserNode.getByteTimeDomainData (native, fast).
@@ -8,15 +9,13 @@ export const Waveform: Component<WaveformProps> = (props) => {
   let canvasRef: HTMLCanvasElement | undefined;
   let ctx: CanvasRenderingContext2D | null = null;
   let animationId: number | undefined;
-  let timeoutId: number | undefined;
   let resizeObserver: ResizeObserver | null = null;
   let themeObserver: MutationObserver | null = null;
   let lastDrawTs = 0;
   let bgColor = '#faf8f5';
   let strokeColor = '#14b8a6';
   const FOREGROUND_FRAME_MS = 33;
-  const IDLE_FRAME_MS = 120;
-  const HIDDEN_FRAME_MS = 250;
+  const pageVisible = usePageVisible();
 
   const updateCanvasSize = () => {
     if (!canvasRef?.parentElement) return;
@@ -37,47 +36,21 @@ export const Waveform: Component<WaveformProps> = (props) => {
     strokeColor = computed.getPropertyValue('--color-primary').trim() || '#14b8a6';
   };
 
-  const scheduleNextFrame = (hidden: boolean, recording: boolean) => {
-    if (!hidden && recording) {
-      if (timeoutId !== undefined) {
-        clearTimeout(timeoutId);
-        timeoutId = undefined;
-      }
-      animationId = requestAnimationFrame(animate);
-      return;
-    }
+  const cancelFrame = () => {
     if (animationId !== undefined) {
       cancelAnimationFrame(animationId);
       animationId = undefined;
     }
-    const nextDelay = hidden ? HIDDEN_FRAME_MS : IDLE_FRAME_MS;
-    timeoutId = window.setTimeout(() => animate(performance.now()), nextDelay);
   };
 
-  const animate = (ts: number) => {
-    if (!ctx || !canvasRef) {
-      scheduleNextFrame(false, props.isRecording);
-      return;
-    }
+  const isActive = () => props.isRecording && pageVisible();
 
-    const hidden = typeof document !== 'undefined' && document.visibilityState !== 'visible';
-    const minFrameInterval = hidden
-      ? HIDDEN_FRAME_MS
-      : props.isRecording
-        ? FOREGROUND_FRAME_MS
-        : IDLE_FRAME_MS;
-    if (ts - lastDrawTs < minFrameInterval) {
-      scheduleNextFrame(hidden, props.isRecording);
-      return;
-    }
-    lastDrawTs = ts;
+  const drawFrame = () => {
+    if (!ctx || !canvasRef) return;
 
     const w = canvasRef.width;
     const h = canvasRef.height;
-    if (w === 0 || h === 0) {
-      scheduleNextFrame(hidden, props.isRecording);
-      return;
-    }
+    if (w === 0 || h === 0) return;
 
     const samples = props.barLevels;
     const n = samples && samples.length > 0 ? samples.length : 0;
@@ -100,8 +73,39 @@ export const Waveform: Component<WaveformProps> = (props) => {
       }
       ctx.stroke();
     }
+  };
 
-    scheduleNextFrame(hidden, props.isRecording);
+  const requestDraw = () => {
+    if (isActive()) {
+      if (animationId === undefined) {
+        animationId = requestAnimationFrame(animate);
+      }
+      return;
+    }
+    cancelFrame();
+    drawFrame();
+  };
+
+  const animate = (ts: number) => {
+    if (!ctx || !canvasRef) {
+      cancelFrame();
+      return;
+    }
+
+    if (!isActive()) {
+      cancelFrame();
+      drawFrame();
+      return;
+    }
+
+    if (ts - lastDrawTs < FOREGROUND_FRAME_MS) {
+      animationId = requestAnimationFrame(animate);
+      return;
+    }
+    lastDrawTs = ts;
+
+    drawFrame();
+    animationId = requestAnimationFrame(animate);
   };
 
   onMount(() => {
@@ -114,22 +118,27 @@ export const Waveform: Component<WaveformProps> = (props) => {
       }
     }
     if (typeof document !== 'undefined') {
-      themeObserver = new MutationObserver(() => refreshThemeColors());
+      themeObserver = new MutationObserver(() => {
+        refreshThemeColors();
+        requestDraw();
+      });
       themeObserver.observe(document.documentElement, {
         attributes: true,
         attributeFilter: ['class'],
       });
     }
-    animate(performance.now());
+    requestDraw();
+  });
+
+  createEffect(() => {
+    pageVisible();
+    props.isRecording;
+    lastDrawTs = 0;
+    requestDraw();
   });
 
   onCleanup(() => {
-    if (animationId !== undefined) {
-      cancelAnimationFrame(animationId);
-    }
-    if (timeoutId !== undefined) {
-      clearTimeout(timeoutId);
-    }
+    cancelFrame();
     resizeObserver?.disconnect();
     themeObserver?.disconnect();
   });

--- a/src/lib/transcription/SentenceBoundaryDetector.test.ts
+++ b/src/lib/transcription/SentenceBoundaryDetector.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, test } from 'vitest';
 import { SentenceBoundaryDetector, type DetectorWord } from './SentenceBoundaryDetector';
 
 describe('SentenceBoundaryDetector', () => {
+    test('cache key preserves distinct texts without hash collisions', () => {
+        const detector = new SentenceBoundaryDetector({ useNLP: false, debug: false }) as any;
+
+        expect(detector.generateCacheKey('hello world')).toBe('hello world');
+        expect(detector.generateCacheKey('hello  world')).toBe('hello  world');
+        expect(detector.generateCacheKey('hello world')).not.toBe(detector.generateCacheKey('hello  world'));
+    });
+
     test('heuristic detection assigns stable wordIndex values by position', () => {
         const detector = new SentenceBoundaryDetector({ useNLP: false, debug: false });
         const repeated: DetectorWord = { text: 'repeat.', start: 0, end: 0.4 };

--- a/src/lib/transcription/SentenceBoundaryDetector.ts
+++ b/src/lib/transcription/SentenceBoundaryDetector.ts
@@ -422,17 +422,10 @@ export class SentenceBoundaryDetector {
     }
 
     /**
-     * Generate a simple hash for caching.
+     * Use the reconstructed text directly so cache lookups remain collision-free.
      */
     private generateCacheKey(text: string): string {
-        let hash = 0;
-        if (text.length === 0) return hash.toString();
-        for (let i = 0; i < text.length; i++) {
-            const char = text.charCodeAt(i);
-            hash = ((hash << 5) - hash) + char;
-            hash = hash & hash; // Convert to 32-bit integer
-        }
-        return hash.toString();
+        return text;
     }
 
     /**

--- a/src/test/vitest.setup.ts
+++ b/src/test/vitest.setup.ts
@@ -1,0 +1,40 @@
+class MemoryStorage implements Storage {
+  #store = new Map<string, string>();
+
+  get length(): number {
+    return this.#store.size;
+  }
+
+  clear(): void {
+    this.#store.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.#store.has(key) ? this.#store.get(key)! : null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.#store.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.#store.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.#store.set(String(key), String(value));
+  }
+}
+
+const installStorage = (name: 'localStorage' | 'sessionStorage') => {
+  if (typeof globalThis[name] !== 'undefined') return;
+
+  Object.defineProperty(globalThis, name, {
+    value: new MemoryStorage(),
+    configurable: true,
+    writable: true,
+  });
+};
+
+installStorage('localStorage');
+installStorage('sessionStorage');

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,34 +53,6 @@ export interface VADConfig {
   minSilenceDuration: number;
 }
 
-// ============================================
-// Transcription Types
-// ============================================
-
-/** Transcript payload emitted by transcription pipeline stages. */
-export interface TranscriptionResult {
-  /** Transcript text for this result. */
-  text: string;
-  /** Token-level details. */
-  tokens: Token[];
-  /** Whether the result is finalized. */
-  isFinal: boolean;
-  /** Emission timestamp in ms. */
-  timestamp: number;
-}
-
-/** Token span with timing and confidence metadata. */
-export interface Token {
-  /** Token text as emitted by decoder/tokenizer. */
-  text: string;
-  /** Start timestamp in seconds. */
-  startTime: number;
-  /** End timestamp in seconds. */
-  endTime: number;
-  /** Confidence score in the range 0-1. */
-  confidence: number;
-}
-
 /** Opaque decoder runtime state for stateful streaming. */
 export interface DecoderState {
   // Opaque state from parakeet.js

--- a/src/utils/usePageVisible.ts
+++ b/src/utils/usePageVisible.ts
@@ -1,0 +1,19 @@
+import { createSignal, onCleanup, onMount, type Accessor } from 'solid-js';
+
+/** Tracks whether the document is currently visible to suspend background-only UI work. */
+export function usePageVisible(): Accessor<boolean> {
+  const [visible, setVisible] = createSignal(
+    typeof document === 'undefined' ? true : document.visibilityState === 'visible'
+  );
+
+  onMount(() => {
+    if (typeof document === 'undefined') return;
+    const handleVisibilityChange = () => {
+      setVisible(document.visibilityState === 'visible');
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    onCleanup(() => document.removeEventListener('visibilitychange', handleVisibilityChange));
+  });
+
+  return visible;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -133,6 +133,7 @@ export default defineConfig({
     pool: 'forks',
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     exclude: [...configDefaults.exclude],
+    setupFiles: ['src/test/vitest.setup.ts'],
     deps: {
       optimizer: {
         web: {


### PR DESCRIPTION
Summary
- land the small correctness/a11y fixes from the issue sweep
- reduce hidden-tab and idle visualizer work across the waveform/debug surfaces
- decouple the compact preview meter from the full visualization tick and surface the energy meter in the main widget

Included
- fix the remaining Solid cleanup bug in `App.tsx`
- make the sentence-boundary NLP cache key collision-free and remove unused shared transcription types
- add quick-settings semantics plus keyboard resizing for the debug panel splitter
- suspend waveform/debug visualizer loops when the page is hidden or idle
- remove hot-path Solid signal churn from `BufferVisualizer`
- add a primary-surface input meter with threshold marker in the floating control widget

Verification
- `npm run build`
- `npm test`
  - same pre-existing environment failure in `src/utils/settingsStorage.test.ts` because `localStorage` is unavailable in this runner
  - touched and adjacent suites passed, including `SentenceBoundaryDetector.test.ts`
- local smoke pass against `npm run dev -- --host 127.0.0.1 --port 4173`
  - opened the app
  - opened the quick settings panel
  - verified the new `Input` meter is present
  - toggled Debug Panel and verified keyboard resize changes the splitter value

Manual Test Focus
- recording widget layout with the new input meter
- hidden-tab resume behavior for the waveform/debug panel
- debug panel keyboard resize behavior
- quick settings panel hover/open/close behavior