### PR TITLE
Remove historical fix reference in VAD tests

### DIFF
--- a/src/lib/audio/energy-calculation.test.ts
+++ b/src/lib/audio/energy-calculation.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for the VAD energy calculation: Peak Amplitude + 6-sample SMA.
  *
- * Matches the logic in AudioEngine (vad-correction-peak-energy fix).
+ * Matches the logic in AudioEngine.
  * legacy UI project uses peak + 6-sample SMA; RMS was causing all-audio-marked-as-silence.
  *
  * Run: npm test


### PR DESCRIPTION
What
Removed the historical reference `(vad-correction-peak-energy fix)` from a documentation comment in `src/lib/audio/energy-calculation.test.ts`.

Why
Automated code health tracking tools treat comments containing the word "fix" (especially when alongside specific issue names) as unresolved tasks or pending TODOs, bloating reports and causing confusion.

Verification
- Verified comment update using `sed`.
- Ran the test suite via `bun test src` to ensure no related tests failed. Note that there are some pre-existing failures due to mock framework issues (`vi.mock`/`vi.stubGlobal` not available in this environment), but no new test failures related to `energy-calculation.test.ts` were introduced.

Result
The codebase remains functional, but automated tracking tools will no longer misidentify the historical note as an open task.