### PR TITLE
Remove unused beforeEach from WindowBuilder tests

### DIFF
--- a/src/lib/transcription/WindowBuilder.test.ts
+++ b/src/lib/transcription/WindowBuilder.test.ts
@@ -7,7 +7,7 @@
  * Run: npm test
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { WindowBuilder } from './WindowBuilder';
 import type { IRingBuffer } from '../audio/types';
 import { VADRingBuffer } from '../vad/VADRingBuffer';


### PR DESCRIPTION
What: Removed the unused `beforeEach` import from `src/lib/transcription/WindowBuilder.test.ts`.
 Why: Removing unused imports reduces clutter, improves code readability, and prevents potential confusion for developers reading the file, contributing to better overall code health.
 Verification: Ran `bun test src` and verified that all 12 tests in `WindowBuilder.test.ts` still pass successfully and no new test failures were introduced.
 Result: A cleaner test file with no unused dependencies.