### PR TITLE
Code health improvement remove unused parakeetmodel import

### DIFF
--- a/src/lib/transcription/transcription.worker.ts
+++ b/src/lib/transcription/transcription.worker.ts
@@ -9,7 +9,6 @@
  * - pipeline v4 utterance mode (UtteranceBasedMerger, cursor-based windowing)
  */
 
-import { ParakeetModel, getParakeetModel } from 'parakeet.js';
 import { TranscriptionService } from './TranscriptionService';
 import { TokenStreamTranscriber } from './TokenStreamTranscriber';
 import { ModelManager } from './ModelManager';


### PR DESCRIPTION
What: Removed unused `ParakeetModel` and `getParakeetModel` import from `src/lib/transcription/transcription.worker.ts`.
 Why: Reduces visual clutter and helps improve maintainability.
 Verification: Ran `tsc --noEmit` and the full `bun test src` test suite to verify no regressions were introduced.
 Result: Cleaned up unused import successfully.