### PR TITLE
[code health remove unused import in App.tsx]

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Component, Show, For, batch, createSignal, createEffect, createMemo, onMount, onCleanup } from 'solid-js';
+import { Component, Show, batch, createSignal, createEffect, createMemo, onMount, onCleanup } from 'solid-js';
 import { appStore } from './stores/appStore';
 import { CompactWaveform, ModelLoadingOverlay, DebugPanel, TranscriptionDisplay, SettingsContent } from './components';
 import { getModelDisplayName, MODELS } from './components/ModelLoadingOverlay';


### PR DESCRIPTION
What: Removed the unused `For` import from `solid-js` at line 1 of `src/App.tsx`.
 Why: Reduces namespace clutter and resolves unused import warnings/errors reported by static analysis tools, improving overall code health and maintainability.
 Verification: Ran the full test suite (`bun test src`) and TypeScript compiler check (`tsc --noEmit`) to confirm no build issues or regressions were introduced.
 Result: A cleaner `src/App.tsx` file with strictly necessary imports and no behavioral changes to the application.