### PR TITLE
[code health improvement] Remove commented-out code in preprocessor-selection.test.ts

### DIFF
--- a/src/lib/transcription/preprocessor-selection.test.ts
+++ b/src/lib/transcription/preprocessor-selection.test.ts
@@ -26,10 +26,7 @@ function simulateHubFileSelection(preprocessorBackend: string | undefined) {
         { key: 'tokenizerUrl', name: 'vocab.txt' },
     ];
 
-    // This replicates the hub.js logic:
-    //   if (preprocessorBackend !== 'js') {
-    //     filesToGet.push({ key: 'preprocessorUrl', name: `${preprocessor}.onnx` });
-    //   }
+    // This replicates the hub.js logic which conditionally pushes the preprocessorUrl if the backend is not 'js'.
     if (preprocessorBackend !== 'js') {
         filesToGet.push({ key: 'preprocessorUrl', name: `${preprocessor}.onnx` });
     }
@@ -39,9 +36,7 @@ function simulateHubFileSelection(preprocessorBackend: string | undefined) {
 
 /**
  * Simulate the fromUrls preprocessor selection logic from parakeet.js/src/parakeet.js.
- * This replicates the exact branching:
- *   const useJsPreprocessor = preprocessorBackend === 'js' || !preprocessorUrl;
- *   const shouldCreateOnnxPreprocessor = !useJsPreprocessor && preprocessorUrl;
+ * This replicates the exact branching logic to determine if the JS or ONNX preprocessor should be used based on backend selection and URL availability.
  */
 function simulateFromUrlsSelection(preprocessorBackend: string | undefined, preprocessorUrl: string | undefined) {
     const useJsPreprocessor = preprocessorBackend === 'js' || !preprocessorUrl;


### PR DESCRIPTION
🎯 **What:** Removed two instances of commented-out code in `src/lib/transcription/preprocessor-selection.test.ts` and replaced them with plain-English descriptive prose.

💡 **Why:** Having literal code blocks in comments (e.g., `if (preprocessorBackend !== 'js') { ... }`) triggers code health linters and static analysis tools that flag "commented-out code". Converting these literal snippets into descriptive prose preserves the contextual documentation (explaining *why* the test logic is branching a certain way) while keeping the codebase clean and compliant with standard health metrics.

✅ **Verification:** 
- Visual inspection confirms the exact comments were replaced.
- Ran `bun test src` to verify no syntactic issues or functional regressions were introduced.
- Code review confirmed the safety and correctness of the change.

✨ **Result:** A cleaner test file that will no longer trigger "commented-out code" warnings, with zero impact on actual test behavior or coverage.

---
*PR created automatically by Jules for task [4154302930430951198](https://jules.google.com/task/4154302930430951198) started by @ysdede*

## Summary by Sourcery

Enhancements:
- Clarify test helper documentation by replacing literal code snippets in comments with plain-English explanations of the branching logic.