### PR TITLE
Remove unused ProcessedSegment import in AudioEngine.ts

### DIFF
--- a/src/lib/audio/AudioEngine.ts
+++ b/src/lib/audio/AudioEngine.ts
@@ -1,6 +1,6 @@
 import { AudioEngine as IAudioEngine, AudioEngineConfig, AudioSegment, IRingBuffer, AudioMetrics } from './types';
 import { RingBuffer } from './RingBuffer';
-import { AudioSegmentProcessor, ProcessedSegment } from './AudioSegmentProcessor';
+import { AudioSegmentProcessor } from './AudioSegmentProcessor';
 import { resampleLinear } from './utils';
 
 /** Duration of the visualization buffer in seconds */


### PR DESCRIPTION
What
Removed the unused `ProcessedSegment` import from `src/lib/audio/AudioEngine.ts` (line 3).

Why
Unused imports add clutter, can trigger linter warnings, and marginally increase parsing overhead. Removing them improves the maintainability and readability of the codebase without changing any behavior.

Verification
- `tsc --noEmit` confirms there are no type-checking errors.
- `bun test src` confirms that no existing tests were broken as a result of this change.
- Code review explicitly confirmed that the change is purely a safe refactoring.

Result
A cleaner `AudioEngine.ts` file with no dead code imports.