### PR TITLE
Add normalizeMelForDisplay tests

### DIFF
--- a/src/lib/audio/mel-display.test.ts
+++ b/src/lib/audio/mel-display.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeMelForDisplay,
+  MEL_DISPLAY_MIN_DB,
+  MEL_DISPLAY_MAX_DB,
+  MEL_DISPLAY_DB_RANGE
+} from './mel-display';
+
+describe('normalizeMelForDisplay', () => {
+  it('maps the minimum boundary to 0', () => {
+    expect(normalizeMelForDisplay(MEL_DISPLAY_MIN_DB)).toBe(0);
+  });
+
+  it('maps the maximum boundary to 1', () => {
+    expect(normalizeMelForDisplay(MEL_DISPLAY_MAX_DB)).toBe(1);
+  });
+
+  it('clamps values below the minimum to 0', () => {
+    expect(normalizeMelForDisplay(MEL_DISPLAY_MIN_DB - 5)).toBe(0);
+  });
+
+  it('clamps values above the maximum to 1', () => {
+    expect(normalizeMelForDisplay(MEL_DISPLAY_MAX_DB + 5)).toBe(1);
+  });
+
+  it('maps the midpoint to 0.5', () => {
+    const midpoint = MEL_DISPLAY_MIN_DB + (MEL_DISPLAY_DB_RANGE / 2);
+    expect(normalizeMelForDisplay(midpoint)).toBeCloseTo(0.5);
+  });
+});


### PR DESCRIPTION
What: This PR adds missing unit tests for the pure math function `normalizeMelForDisplay` in `src/lib/audio/mel-display.ts`.
 Coverage: The test suite evaluates exact minimum bounds, maximum bounds, clamped lower bounds, clamped upper bounds, and linear midpoint calculations using `toBeCloseTo`.
 Result: Test coverage improved for the core mel processing scaling functions with all edge cases completely handled.