### PR TITLE
[security fix remove URL.createObjectURL]

### DIFF
--- a/src/lib/audio/AudioEngine.ts
+++ b/src/lib/audio/AudioEngine.ts
@@ -1,3 +1,4 @@
+import captureProcessorUrl from "./capture-processor.ts?worker&url";
 import { AudioEngine as IAudioEngine, AudioEngineConfig, AudioSegment, IRingBuffer, AudioMetrics } from './types';
 import { RingBuffer } from './RingBuffer';
 import { AudioSegmentProcessor, ProcessedSegment } from './AudioSegmentProcessor';
@@ -202,84 +203,7 @@ export class AudioEngine implements IAudioEngine {
         });
 
         if (!this.isWorkletInitialized) {
-            const windowDuration = 0.080;
-            const processorCode = `
-                class CaptureProcessor extends AudioWorkletProcessor {
-                    constructor(options) {
-                        super(options);
-                        const opts = options?.processorOptions || {};
-                        this.inputSampleRate = opts.inputSampleRate || 16000;
-                        this.targetSampleRate = opts.targetSampleRate || this.inputSampleRate;
-                        this.ratio = this.inputSampleRate / this.targetSampleRate;
-                        this.bufferSize = Math.round(${windowDuration} * this.inputSampleRate);
-                        this.buffer = new Float32Array(this.bufferSize);
-                        this.index = 0;
-                        this._lastLog = 0;
-                    }
-
-                    _emitChunk() {
-                        let out;
-                        let maxAbs = 0;
-
-                        if (this.targetSampleRate === this.inputSampleRate) {
-                            out = new Float32Array(this.bufferSize);
-                            for (let i = 0; i < this.bufferSize; i++) {
-                                const v = this.buffer[i];
-                                out[i] = v;
-                                const a = v < 0 ? -v : v;
-                                if (a > maxAbs) maxAbs = a;
-                            }
-                        } else {
-                            const outLength = Math.floor(this.bufferSize / this.ratio);
-                            out = new Float32Array(outLength);
-                            for (let i = 0; i < outLength; i++) {
-                                const srcIndex = i * this.ratio;
-                                const srcIndexFloor = Math.floor(srcIndex);
-                                const srcIndexCeil = Math.min(srcIndexFloor + 1, this.bufferSize - 1);
-                                const t = srcIndex - srcIndexFloor;
-                                const v = this.buffer[srcIndexFloor] * (1 - t) + this.buffer[srcIndexCeil] * t;
-                                out[i] = v;
-                                const a = v < 0 ? -v : v;
-                                if (a > maxAbs) maxAbs = a;
-                            }
-                        }
-
-                        this.port.postMessage(
-                            { type: 'audio', samples: out, sampleRate: this.targetSampleRate, maxAbs },
-                            [out.buffer]
-                        );
-                    }
-
-                    process(inputs) {
-                        const input = inputs[0];
-                        if (!input || !input[0]) return true;
-                        
-                        const channelData = input[0];
-                        
-                        // Buffer the data
-                        for (let i = 0; i < channelData.length; i++) {
-                            this.buffer[this.index++] = channelData[i];
-                            
-                            if (this.index >= this.bufferSize) {
-                                this._emitChunk();
-                                this.index = 0;
-                                
-                                // Debug log every ~5 seconds
-                                const now = Date.now();
-                                if (now - this._lastLog > 5000) {
-                                    this.port.postMessage({ type: 'log', message: '[AudioWorklet] Active' });
-                                    this._lastLog = now;
-                                }
-                            }
-                        }
-                        
-                        return true;
-                    }
-                }
-                registerProcessor('capture-processor', CaptureProcessor);
-            `;
-            const blob = new Blob([processorCode], { type: 'application/javascript' });
-            const url = URL.createObjectURL(blob);
+            const url = captureProcessorUrl;
             try {
                 await this.audioContext.audioWorklet.addModule(url);
                 this.isWorkletInitialized = true;

--- a/src/lib/audio/capture-processor.ts
+++ b/src/lib/audio/capture-processor.ts
@@ -1,21 +1,84 @@
-/**
- * Simple AudioWorkletProcessor for capturing raw audio chunks.
- * Minimal logic to keep latency low.
- */
 class CaptureProcessor extends AudioWorkletProcessor {
+    inputSampleRate: number;
+    targetSampleRate: number;
+    ratio: number;
+    bufferSize: number;
+    buffer: Float32Array;
+    index: number;
+    _lastLog: number;
+
+    constructor(options?: AudioWorkletNodeOptions) {
+        super(options);
+        const opts = options?.processorOptions || {};
+        this.inputSampleRate = opts.inputSampleRate || 16000;
+        this.targetSampleRate = opts.targetSampleRate || this.inputSampleRate;
+        this.ratio = this.inputSampleRate / this.targetSampleRate;
+
+        // 0.080 seconds window duration as defined in AudioEngine
+        const windowDuration = 0.080;
+        this.bufferSize = Math.round(windowDuration * this.inputSampleRate);
+        this.buffer = new Float32Array(this.bufferSize);
+        this.index = 0;
+        this._lastLog = 0;
+    }
+
+    _emitChunk() {
+        let out: Float32Array;
+        let maxAbs = 0;
+
+        if (this.targetSampleRate === this.inputSampleRate) {
+            out = new Float32Array(this.bufferSize);
+            for (let i = 0; i < this.bufferSize; i++) {
+                const v = this.buffer[i];
+                out[i] = v;
+                const a = v < 0 ? -v : v;
+                if (a > maxAbs) maxAbs = a;
+            }
+        } else {
+            const outLength = Math.floor(this.bufferSize / this.ratio);
+            out = new Float32Array(outLength);
+            for (let i = 0; i < outLength; i++) {
+                const srcIndex = i * this.ratio;
+                const srcIndexFloor = Math.floor(srcIndex);
+                const srcIndexCeil = Math.min(srcIndexFloor + 1, this.bufferSize - 1);
+                const t = srcIndex - srcIndexFloor;
+                const v = this.buffer[srcIndexFloor] * (1 - t) + this.buffer[srcIndexCeil] * t;
+                out[i] = v;
+                const a = v < 0 ? -v : v;
+                if (a > maxAbs) maxAbs = a;
+            }
+        }
+
+        this.port.postMessage(
+            { type: 'audio', samples: out, sampleRate: this.targetSampleRate, maxAbs },
+            [out.buffer]
+        );
+    }
+
     process(inputs: Float32Array[][], _outputs: Float32Array[][]): boolean {
         const input = inputs[0];
-        if (!input || input.length === 0) return true;
+        if (!input || !input[0]) return true;
 
-        // Use only the first channel (mono)
         const channelData = input[0];
 
-        // Send audio chunk to the main thread
-        // We clone the data to avoid issues with SharedArrayBuffer (if not available)
-        this.port.postMessage(channelData);
+        // Buffer the data
+        for (let i = 0; i < channelData.length; i++) {
+            this.buffer[this.index++] = channelData[i];
+
+            if (this.index >= this.bufferSize) {
+                this._emitChunk();
+                this.index = 0;
+
+                // Debug log every ~5 seconds
+                const now = Date.now();
+                if (now - this._lastLog > 5000) {
+                    this.port.postMessage({ type: 'log', message: '[AudioWorklet] Active' });
+                    this._lastLog = now;
+                }
+            }
+        }
 
         return true;
     }
 }
-
 registerProcessor('capture-processor', CaptureProcessor);


### PR DESCRIPTION
### What
The `AudioEngine` was using `URL.createObjectURL` to dynamically load an `AudioWorkletProcessor` from a string representation of JavaScript code. This creates a potential structural security vulnerability (and often violates strict Content Security Policies).

### Risk
While the string itself was hardcoded, relying on `URL.createObjectURL` with dynamic string-to-blob generation is a security risk. In environments with strict CSP (Content Security Policy) settings, such execution would be blocked, breaking the application.

### Solution
1. Moved the `CaptureProcessor` class logic into a dedicated file: `src/lib/audio/capture-processor.ts`.
2. Updated `src/lib/audio/AudioEngine.ts` to statically import the processor using Vite's `?worker&url` syntax (`import captureProcessorUrl from "./capture-processor.ts?worker&url";`).
3. Replaced the Blob generation and `URL.createObjectURL` logic with the imported URL.

This ensures the processor logic is safely bundled and served just like any other JavaScript asset, completely removing the reliance on dynamic object URLs and making the code more secure and CSP-compliant.

---
*PR created automatically by Jules for task [7955038781501531852](https://jules.google.com/task/7955038781501531852) started by @ysdede*

## Summary by Sourcery

Statically load the audio capture worklet processor instead of constructing it from a runtime-generated blob URL to improve security and CSP compatibility.

Bug Fixes:
- Eliminate use of URL.createObjectURL for the audio capture worklet to avoid CSP violations and structural security risks.

Enhancements:
- Move the CaptureProcessor AudioWorklet implementation into a dedicated module and reuse it from AudioEngine via a bundled worker URL.